### PR TITLE
Add other accents

### DIFF
--- a/src/ast/builtins/types.ts
+++ b/src/ast/builtins/types.ts
@@ -1,4 +1,4 @@
-export enum LatexBuiltinType {
+export enum BuiltinType {
 	Begin = 1,
 	End = 2,
 	Item = 3,

--- a/src/ast/fonts/commands/author.test.ts
+++ b/src/ast/fonts/commands/author.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it, test } from "bun:test";
 
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	LatexTokenType,
+	TokenType,
 } from "../../../lexer/types";
 import {
 	type AuthorCommand,
 	AuthorCommandType,
+	type AuthorDefaults,
+	FontShapeValue,
+	FontSizeUnit,
 	FontValueType,
-	type LatexAuthorDefaults,
-	LatexFontShapeValue,
-	LatexFontSizeUnit,
-	LatexFontWeight,
-	LatexFontWidth,
+	FontWeight,
+	FontWidth,
 } from "../types";
 import { parseAuthorCommand, setFontDefaults } from "./author";
 
@@ -186,7 +186,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 5, unit: LatexFontSizeUnit.Point },
+					value: { value: 5, unit: FontSizeUnit.Point },
 				},
 			},
 			"tiny",
@@ -196,7 +196,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 7, unit: LatexFontSizeUnit.Point },
+					value: { value: 7, unit: FontSizeUnit.Point },
 				},
 			},
 			"scriptsize",
@@ -206,7 +206,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 8, unit: LatexFontSizeUnit.Point },
+					value: { value: 8, unit: FontSizeUnit.Point },
 				},
 			},
 			"footnotesize",
@@ -216,7 +216,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 10, unit: LatexFontSizeUnit.Point },
+					value: { value: 10, unit: FontSizeUnit.Point },
 				},
 			},
 			"normalsize",
@@ -226,7 +226,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 12, unit: LatexFontSizeUnit.Point },
+					value: { value: 12, unit: FontSizeUnit.Point },
 				},
 			},
 			"large",
@@ -236,7 +236,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 14.4, unit: LatexFontSizeUnit.Point },
+					value: { value: 14.4, unit: FontSizeUnit.Point },
 				},
 			},
 			"Large",
@@ -246,7 +246,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 17.28, unit: LatexFontSizeUnit.Point },
+					value: { value: 17.28, unit: FontSizeUnit.Point },
 				},
 			},
 			"LARGE",
@@ -256,7 +256,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 20.74, unit: LatexFontSizeUnit.Point },
+					value: { value: 20.74, unit: FontSizeUnit.Point },
 				},
 			},
 			"huge",
@@ -266,7 +266,7 @@ describe("parseAuthorCommand", () => {
 				type: AuthorCommandType.FontSize,
 				value: {
 					type: FontValueType.FontValue,
-					value: { value: 24.88, unit: LatexFontSizeUnit.Point },
+					value: { value: 24.88, unit: FontSizeUnit.Point },
 				},
 			},
 			"Huge",
@@ -280,15 +280,15 @@ describe("parseAuthorCommand", () => {
 describe("setFontDefaults", () => {
 	it("should throw an error if the command is not renewcommand", () => {
 		const renewCommand: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\notrenewcommand",
 			name: "notrenewcommand",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\defaultrm",
 							name: "defaultrm",
 							arguments: [],
@@ -296,10 +296,10 @@ describe("setFontDefaults", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "bx",
 							originalLength: 2,
 						},
@@ -312,7 +312,7 @@ describe("setFontDefaults", () => {
 
 	it("should throw an error if the number of arguments is not 2", () => {
 		const renewCommand: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\renewcommand",
 			name: "renewcommand",
 			arguments: [],
@@ -322,25 +322,25 @@ describe("setFontDefaults", () => {
 
 	it("should throw an error if the first argument is not a command", () => {
 		const renewCommand: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\renewcommand",
 			name: "renewcommand",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "bx",
 							originalLength: 2,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\defaultrm",
 							name: "defaultrm",
 							arguments: [],
@@ -356,15 +356,15 @@ describe("setFontDefaults", () => {
 
 	it("should throw an error if the second argument is not a command or argument", () => {
 		const renewCommand: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\renewcommand",
 			name: "renewcommand",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\rmdefault",
 							name: "rmdefault",
 							arguments: [],
@@ -372,10 +372,10 @@ describe("setFontDefaults", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Placeholder,
+							type: TokenType.Placeholder,
 							literal: "#1",
 							content: 1,
 						},
@@ -386,7 +386,7 @@ describe("setFontDefaults", () => {
 		expect(() => setFontDefaults(renewCommand)).toThrow();
 	});
 
-	test.each<[LatexAuthorDefaults, string, string]>([
+	test.each<[AuthorDefaults, string, string]>([
 		[
 			{
 				serif: {
@@ -432,8 +432,8 @@ describe("setFontDefaults", () => {
 				bold: {
 					type: FontValueType.FontValue,
 					value: {
-						width: LatexFontWidth.Expanded,
-						weight: LatexFontWeight.Bold,
+						width: FontWidth.Expanded,
+						weight: FontWeight.Bold,
 					},
 				},
 			},
@@ -445,8 +445,8 @@ describe("setFontDefaults", () => {
 				series: {
 					type: FontValueType.FontValue,
 					value: {
-						width: LatexFontWidth.Expanded,
-						weight: LatexFontWeight.Bold,
+						width: FontWidth.Expanded,
+						weight: FontWeight.Bold,
 					},
 				},
 			},
@@ -458,8 +458,8 @@ describe("setFontDefaults", () => {
 				medium: {
 					type: FontValueType.FontValue,
 					value: {
-						width: LatexFontWidth.Expanded,
-						weight: LatexFontWeight.Bold,
+						width: FontWidth.Expanded,
+						weight: FontWeight.Bold,
 					},
 				},
 			},
@@ -470,7 +470,7 @@ describe("setFontDefaults", () => {
 			{
 				shape: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 			"shapedefault",
@@ -480,7 +480,7 @@ describe("setFontDefaults", () => {
 			{
 				italics: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 			"itdefault",
@@ -490,7 +490,7 @@ describe("setFontDefaults", () => {
 			{
 				smallCaps: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 			"scdefault",
@@ -500,7 +500,7 @@ describe("setFontDefaults", () => {
 			{
 				spacedSmallCaps: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 			"sscdefault",
@@ -510,7 +510,7 @@ describe("setFontDefaults", () => {
 			{
 				swash: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 			"swdefault",
@@ -520,7 +520,7 @@ describe("setFontDefaults", () => {
 			{
 				oblique: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 			"sldefault",
@@ -530,15 +530,15 @@ describe("setFontDefaults", () => {
 		"should return $o given a command name of %s and a value of %s",
 		(want, commandName, value) => {
 			const renewCommand: CommandToken = {
-				type: LatexTokenType.Command,
+				type: TokenType.Command,
 				literal: "\\renewcommand",
 				name: "renewcommand",
 				arguments: [
 					{
-						type: LatexCommandArgumentType.Required,
+						type: CommandArgumentType.Required,
 						content: [
 							{
-								type: LatexTokenType.Command,
+								type: TokenType.Command,
 								literal: `\\${commandName}`,
 								name: `${commandName}`,
 								arguments: [],
@@ -546,10 +546,10 @@ describe("setFontDefaults", () => {
 						],
 					},
 					{
-						type: LatexCommandArgumentType.Required,
+						type: CommandArgumentType.Required,
 						content: [
 							{
-								type: LatexTokenType.Content,
+								type: TokenType.Content,
 								literal: value,
 								originalLength: value.length,
 							},

--- a/src/ast/fonts/commands/author.ts
+++ b/src/ast/fonts/commands/author.ts
@@ -1,16 +1,16 @@
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	LatexTokenType,
 	type RequiredArgument,
+	TokenType,
 } from "../../../lexer/types";
 import {
 	type AuthorCommand,
 	AuthorCommandType,
+	type AuthorDefaults,
+	type FontMeasurementValue,
+	FontSizeUnit,
 	FontValueType,
-	type LatexAuthorDefaults,
-	type LatexFontMeasurementValue,
-	LatexFontSizeUnit,
 } from "../types";
 import {
 	parseFontFamily,
@@ -19,18 +19,14 @@ import {
 	parseToFontValue,
 } from "../utils";
 
-function createAuthorDefaultCommand(
-	cmd: keyof LatexAuthorDefaults,
-): AuthorCommand {
+function createAuthorDefaultCommand(cmd: keyof AuthorDefaults): AuthorCommand {
 	return {
 		type: AuthorCommandType.AuthorDefault,
 		value: cmd,
 	};
 }
 
-function createAuthorSizeCommand(
-	size: LatexFontMeasurementValue,
-): AuthorCommand {
+function createAuthorSizeCommand(size: FontMeasurementValue): AuthorCommand {
 	return {
 		type: AuthorCommandType.FontSize,
 		value: {
@@ -87,47 +83,47 @@ export function parseAuthorCommand(
 		case "tiny":
 			return createAuthorSizeCommand({
 				value: 5,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "scriptsize":
 			return createAuthorSizeCommand({
 				value: 7,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "footnotesize":
 			return createAuthorSizeCommand({
 				value: 8,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "normalsize":
 			return createAuthorSizeCommand({
 				value: 10,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "large":
 			return createAuthorSizeCommand({
 				value: 12,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "Large":
 			return createAuthorSizeCommand({
 				value: 14.4,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "LARGE":
 			return createAuthorSizeCommand({
 				value: 17.28,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "huge":
 			return createAuthorSizeCommand({
 				value: 20.74,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		case "Huge":
 			return createAuthorSizeCommand({
 				value: 24.88,
-				unit: LatexFontSizeUnit.Point,
+				unit: FontSizeUnit.Point,
 			});
 		default:
 			return null;
@@ -136,7 +132,7 @@ export function parseAuthorCommand(
 
 function determineAuthorCommandKey(
 	commandName: string,
-): keyof LatexAuthorDefaults | null {
+): keyof AuthorDefaults | null {
 	const namePieces = commandName.split("default");
 	if (namePieces.length !== 2) {
 		return null;
@@ -178,17 +174,17 @@ function determineAuthorCommandKey(
 
 export function setFontDefaults(
 	renewCommand: CommandToken,
-): Partial<LatexAuthorDefaults> | null {
+): Partial<AuthorDefaults> | null {
 	if (renewCommand.name !== "renewcommand") {
 		throw new Error(
 			"Font defaults can only be set with the renewcommand command",
 		);
 	}
-	const fontDefaults: Partial<LatexAuthorDefaults> = {};
+	const fontDefaults: Partial<AuthorDefaults> = {};
 	if (
 		renewCommand.arguments.length !== 2 ||
 		renewCommand.arguments.every(
-			(arg) => arg.type !== LatexCommandArgumentType.Required,
+			(arg) => arg.type !== CommandArgumentType.Required,
 		)
 	) {
 		throw new Error("Expected two required commands to follow renewcommand");
@@ -198,7 +194,7 @@ export function setFontDefaults(
 		(a) => a.content as RequiredArgument["content"],
 	);
 
-	if (arg1.length !== 1 || arg1[0].type !== LatexTokenType.Command) {
+	if (arg1.length !== 1 || arg1[0].type !== TokenType.Command) {
 		throw new Error("First required argument must be a command");
 	}
 	const [command] = arg1;
@@ -214,8 +210,7 @@ export function setFontDefaults(
 
 	if (
 		arg2.length !== 1 ||
-		(arg2[0].type !== LatexTokenType.Command &&
-			arg2[0].type !== LatexTokenType.Content)
+		(arg2[0].type !== TokenType.Command && arg2[0].type !== TokenType.Content)
 	) {
 		throw new Error("Second required argument must be a command or argument");
 	}

--- a/src/ast/fonts/commands/declarations.test.ts
+++ b/src/ast/fonts/commands/declarations.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	LatexTokenType,
+	TokenType,
 } from "../../../lexer/types";
 import {
 	AuthorCommandType,
+	FontEncodingNormalValue,
+	FontEncodingType,
+	FontShapeValue,
+	FontSizeUnit,
 	FontValueType,
-	LatexFontEncodingNormalValue,
-	LatexFontEncodingType,
-	LatexFontShapeValue,
-	LatexFontSizeUnit,
-	LatexFontWeight,
-	LatexFontWidth,
+	FontWeight,
+	FontWidth,
 } from "../types";
 import {
 	parseDeclareFixedFont,
@@ -23,7 +23,7 @@ import {
 describe("parseDeclareFixedFont", () => {
 	it("should throw an error if the command is not named DeclareFixedFont", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareTextFont",
 			name: "DeclareTextFont",
 			arguments: [],
@@ -33,7 +33,7 @@ describe("parseDeclareFixedFont", () => {
 
 	it("should throw an error if the command does not have 6 arguments", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareFixedFont",
 			name: "DeclareFixedFont",
 			arguments: [],
@@ -43,65 +43,65 @@ describe("parseDeclareFixedFont", () => {
 
 	it("should throw an error if the first argument is not a macro", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareFixedFont",
 			name: "DeclareFixedFont",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "name",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "OT1",
 							originalLength: 3,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "cmr",
 							originalLength: 3,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "m",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "n",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "5",
 							originalLength: 1,
 						},
@@ -114,15 +114,15 @@ describe("parseDeclareFixedFont", () => {
 
 	it("should create a fixed font if all the parameters are valid values", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareFixedFont",
 			name: "DeclareFixedFont",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\myfont",
 							name: "myfont",
 							arguments: [],
@@ -130,50 +130,50 @@ describe("parseDeclareFixedFont", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "OT1",
 							originalLength: 3,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "cmr",
 							originalLength: 3,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "m",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "n",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "5",
 							originalLength: 1,
 						},
@@ -187,8 +187,8 @@ describe("parseDeclareFixedFont", () => {
 			encoding: {
 				type: FontValueType.FontValue,
 				value: {
-					encoding: LatexFontEncodingNormalValue.KnuthTexText,
-					type: LatexFontEncodingType.Normal,
+					encoding: FontEncodingNormalValue.KnuthTexText,
+					type: FontEncodingType.Normal,
 				},
 			},
 			family: {
@@ -199,18 +199,18 @@ describe("parseDeclareFixedFont", () => {
 			series: {
 				type: FontValueType.FontValue,
 				value: {
-					weight: LatexFontWeight.Medium,
-					width: LatexFontWidth.Medium,
+					weight: FontWeight.Medium,
+					width: FontWidth.Medium,
 				},
 			},
 			shape: {
 				type: FontValueType.FontValue,
-				value: LatexFontShapeValue.Normal,
+				value: FontShapeValue.Normal,
 			},
 			size: {
 				type: FontValueType.FontValue,
 				value: {
-					unit: LatexFontSizeUnit.Point,
+					unit: FontSizeUnit.Point,
 					value: 5,
 				},
 			},
@@ -221,7 +221,7 @@ describe("parseDeclareFixedFont", () => {
 describe("parseDeclareTextFontCommand", () => {
 	it("should throw an error if the command is not named DeclareTextFontCommand", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareFixedFont",
 			name: "DeclareFixedFont",
 			arguments: [],
@@ -231,7 +231,7 @@ describe("parseDeclareTextFontCommand", () => {
 
 	it("should throw an error if the command does not have 2 arguments", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareTextFont",
 			name: "DeclareTextFont",
 			arguments: [],
@@ -241,25 +241,25 @@ describe("parseDeclareTextFontCommand", () => {
 
 	it("should throw an error if the first argument is not a macro", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareTextFont",
 			name: "DeclareTextFont",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "name",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "switch1 switch2",
 							originalLength: 16,
 						},
@@ -272,15 +272,15 @@ describe("parseDeclareTextFontCommand", () => {
 
 	it("should throw an error if the second argument contains invalid switches", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareTextFont",
 			name: "DeclareTextFont",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\myfont",
 							name: "myfont",
 							arguments: [],
@@ -288,10 +288,10 @@ describe("parseDeclareTextFontCommand", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\invalidswitch",
 							name: "invalidswitch",
 							arguments: [],
@@ -305,15 +305,15 @@ describe("parseDeclareTextFontCommand", () => {
 
 	it("should parse the command correctly if all arguments are valid", () => {
 		const command: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\DeclareTextFont",
 			name: "DeclareTextFont",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\myswitch",
 							name: "myswitch",
 							arguments: [],
@@ -321,16 +321,16 @@ describe("parseDeclareTextFontCommand", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\normalfont",
 							name: "normalfont",
 							arguments: [],
 						},
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\itshape",
 							name: "itshape",
 							arguments: [],

--- a/src/ast/fonts/commands/declarations.ts
+++ b/src/ast/fonts/commands/declarations.ts
@@ -1,8 +1,8 @@
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	LatexTokenType,
 	type RequiredArgument,
+	TokenType,
 } from "../../../lexer/types";
 import type {
 	AuthorCommand,
@@ -31,7 +31,7 @@ export function parseDeclareFixedFont(
 	const args = command.arguments;
 	if (
 		args.length !== 6 ||
-		args.every((arg) => arg.type !== LatexCommandArgumentType.Required) ||
+		args.every((arg) => arg.type !== CommandArgumentType.Required) ||
 		args.every((arg) => (arg as RequiredArgument).content.length !== 1)
 	) {
 		throw new Error("DeclareFixedFont command must have 6 arguments");
@@ -42,7 +42,7 @@ export function parseDeclareFixedFont(
 
 	if (
 		nameArg.content.length !== 1 ||
-		nameArg.content[0].type !== LatexTokenType.Command
+		nameArg.content[0].type !== TokenType.Command
 	) {
 		throw new Error("First argument must be macro to add");
 	}
@@ -76,7 +76,7 @@ export function parseDeclareTextFontCommand(
 	const args = command.arguments;
 	if (
 		args.length !== 2 ||
-		args.every((arg) => arg.type !== LatexCommandArgumentType.Required)
+		args.every((arg) => arg.type !== CommandArgumentType.Required)
 	) {
 		throw new Error("DeclareTextFontCommand command must have 2 arguments");
 	}
@@ -85,7 +85,7 @@ export function parseDeclareTextFontCommand(
 
 	if (
 		nameArg.content.length !== 1 ||
-		nameArg.content[0].type !== LatexTokenType.Command
+		nameArg.content[0].type !== TokenType.Command
 	) {
 		throw new Error("First argument must be the macro create");
 	}
@@ -94,7 +94,7 @@ export function parseDeclareTextFontCommand(
 
 	const authorCommands: AuthorCommand[] = [];
 	for (const token of switchArg.content) {
-		if (token.type !== LatexTokenType.Command || token.arguments.length !== 0) {
+		if (token.type !== TokenType.Command || token.arguments.length !== 0) {
 			throw new Error(
 				"Second argument must be a list of switches with no arguments",
 			);
@@ -126,7 +126,7 @@ export function parseDeclareOldFont(
 	const args = command.arguments;
 	if (
 		args.length !== 2 ||
-		args.every((arg) => arg.type !== LatexCommandArgumentType.Required)
+		args.every((arg) => arg.type !== CommandArgumentType.Required)
 	) {
 		throw new Error("DeclareTextFontCommand command must have 2 arguments");
 	}
@@ -135,7 +135,7 @@ export function parseDeclareOldFont(
 
 	if (
 		nameArg.content.length !== 1 ||
-		nameArg.content[0].type !== LatexTokenType.Command
+		nameArg.content[0].type !== TokenType.Command
 	) {
 		throw new Error("First argument must be the macro create");
 	}
@@ -144,7 +144,7 @@ export function parseDeclareOldFont(
 
 	const authorCommands: AuthorCommand[] = [];
 	for (const token of textSwitches.content) {
-		if (token.type !== LatexTokenType.Command || token.arguments.length !== 0) {
+		if (token.type !== TokenType.Command || token.arguments.length !== 0) {
 			throw new Error(
 				"Second argument must be a list of switches with no arguments",
 			);

--- a/src/ast/fonts/commands/macros.test.ts
+++ b/src/ast/fonts/commands/macros.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { LatexFontCurrentValues } from "../types";
+import type { FontCurrentValues } from "../types";
 import { determineCurrentFontKey } from "./macros";
 
 describe("determineCurrentFontKey", () => {
@@ -16,6 +16,6 @@ describe("determineCurrentFontKey", () => {
 		["unknownCommand", null],
 	])("should return %s given %s", (commandName, expected) => {
 		const result = determineCurrentFontKey(commandName);
-		expect(result).toEqual(expected as keyof LatexFontCurrentValues);
+		expect(result).toEqual(expected as keyof FontCurrentValues);
 	});
 });

--- a/src/ast/fonts/commands/macros.ts
+++ b/src/ast/fonts/commands/macros.ts
@@ -1,8 +1,8 @@
-import type { LatexFontCurrentValues } from "../types";
+import type { FontCurrentValues } from "../types";
 
 export function determineCurrentFontKey(
 	commandName: string,
-): keyof LatexFontCurrentValues | null {
+): keyof FontCurrentValues | null {
 	switch (commandName.toLocaleLowerCase()) {
 		case "f@encoding":
 			return "encoding";

--- a/src/ast/fonts/commands/selection.test.ts
+++ b/src/ast/fonts/commands/selection.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it, test } from "bun:test";
 
-import { LatexLexer } from "../../../lexer/lexer";
+import { Lexer } from "../../../lexer/lexer";
 import {
+	type Font,
+	FontEncodingNormalValue,
+	FontEncodingType,
+	FontShapeValue,
+	FontSizeUnit,
 	FontValueType,
-	type LatexFont,
-	LatexFontEncodingNormalValue,
-	LatexFontEncodingType,
-	LatexFontShapeValue,
-	LatexFontSizeUnit,
-	LatexFontWeight,
-	LatexFontWidth,
+	FontWeight,
+	FontWidth,
 } from "../types";
 import { parseSelectionCommandSections, parseUseFont } from "./selection";
 
 describe("parseSelectionCommandSections", () => {
-	test.each<[LatexFont, string]>([
+	test.each<[Font, string]>([
 		[
 			{
 				encoding: {
 					type: FontValueType.FontValue,
 					value: {
-						type: LatexFontEncodingType.Local,
+						type: FontEncodingType.Local,
 						encoding: "lt1",
 					},
 				},
@@ -29,26 +29,26 @@ describe("parseSelectionCommandSections", () => {
 					type: FontValueType.FontValue,
 					value: {
 						value: 10,
-						unit: LatexFontSizeUnit.Inch,
+						unit: FontSizeUnit.Inch,
 					},
 				},
 				baselineSkip: {
 					type: FontValueType.FontValue,
 					value: {
 						value: 12,
-						unit: LatexFontSizeUnit.Point,
+						unit: FontSizeUnit.Point,
 					},
 				},
 				series: {
 					type: FontValueType.FontValue,
 					value: {
-						weight: LatexFontWeight.SemiLight,
-						width: LatexFontWidth.UltraCondensed,
+						weight: FontWeight.SemiLight,
+						width: FontWidth.UltraCondensed,
 					},
 				},
 				shape: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 				lineSpread: { type: FontValueType.FontValue, value: 1.5 },
 			},
@@ -59,29 +59,29 @@ describe("parseSelectionCommandSections", () => {
 				encoding: {
 					type: FontValueType.FontValue,
 					value: {
-						type: LatexFontEncodingType.Normal,
-						encoding: LatexFontEncodingNormalValue.MathItalic,
+						type: FontEncodingType.Normal,
+						encoding: FontEncodingNormalValue.MathItalic,
 					},
 				},
 				size: {
 					type: FontValueType.FontValue,
 					value: {
 						value: 11,
-						unit: LatexFontSizeUnit.Point,
+						unit: FontSizeUnit.Point,
 					},
 				},
 				baselineSkip: {
 					type: FontValueType.FontValue,
 					value: {
 						value: 13,
-						unit: LatexFontSizeUnit.Ex,
+						unit: FontSizeUnit.Ex,
 					},
 				},
 			},
 			"\\fontencoding{oml}\\fontsize{11}{13ex}\\selectfont",
 		],
 	])("should return $o for an input of %s", (want, input) => {
-		const tokens = new LatexLexer(input).readToEnd();
+		const tokens = new Lexer(input).readToEnd();
 		const got = parseSelectionCommandSections(tokens);
 		expect(got).toEqual(want);
 	});
@@ -95,14 +95,14 @@ describe("parseSelectionCommandSections", () => {
 		"\\fontsize{12none}{12}\\selectfont",
 		"\\fontsize{none}{12}\\selectfont",
 	])("should throw an error for an input of %s", (input) => {
-		const tokens = new LatexLexer(input).readToEnd();
+		const tokens = new Lexer(input).readToEnd();
 		expect(() => parseSelectionCommandSections(tokens)).toThrow();
 	});
 });
 
 describe("parseUseFont", () => {
 	it("should parse the encoding, family, weight, width and shape of a font", () => {
-		const tokens = new LatexLexer("\\usefont{oml}{ptm}{sluc}{it}").readToEnd();
+		const tokens = new Lexer("\\usefont{oml}{ptm}{sluc}{it}").readToEnd();
 		expect(tokens).toHaveLength(1);
 		const [token] = tokens;
 		const got = parseUseFont(token);
@@ -110,48 +110,46 @@ describe("parseUseFont", () => {
 			encoding: {
 				type: FontValueType.FontValue,
 				value: {
-					type: LatexFontEncodingType.Normal,
-					encoding: LatexFontEncodingNormalValue.MathItalic,
+					type: FontEncodingType.Normal,
+					encoding: FontEncodingNormalValue.MathItalic,
 				},
 			},
 			family: { type: FontValueType.FontValue, value: "ptm" },
 			series: {
 				type: FontValueType.FontValue,
 				value: {
-					weight: LatexFontWeight.SemiLight,
-					width: LatexFontWidth.UltraCondensed,
+					weight: FontWeight.SemiLight,
+					width: FontWidth.UltraCondensed,
 				},
 			},
 			shape: {
 				type: FontValueType.FontValue,
-				value: LatexFontShapeValue.Italic,
+				value: FontShapeValue.Italic,
 			},
 		});
 	});
 
 	it("should throw if the command is not recognized", () => {
-		const token = new LatexLexer(
-			"\\fontstuff{oml}{ptm}{sluc}{it}",
-		).readToEnd()[0];
+		const token = new Lexer("\\fontstuff{oml}{ptm}{sluc}{it}").readToEnd()[0];
 		expect(() => parseUseFont(token)).toThrow();
 	});
 
 	it("should throw if less than four arguments are provided", () => {
-		const token = new LatexLexer("\\usefont{oml}{ptm}{sluc}").readToEnd()[0];
+		const token = new Lexer("\\usefont{oml}{ptm}{sluc}").readToEnd()[0];
 		expect(() => parseUseFont(token)).toThrow();
 	});
 
 	it("should throw if any of the arguments cannot be parsed", () => {
-		let lexer = new LatexLexer("\\usefont{oml}{ptm}{sluc}{unknown}");
+		let lexer = new Lexer("\\usefont{oml}{ptm}{sluc}{unknown}");
 		expect(() => parseUseFont(lexer.readToEnd()[0])).toThrow();
 
-		lexer = new LatexLexer("\\usefont{oml}{ptm}{}{it}");
+		lexer = new Lexer("\\usefont{oml}{ptm}{}{it}");
 		expect(() => parseUseFont(lexer.readToEnd()[0])).toThrow();
 
-		lexer = new LatexLexer("\\usefont{oml}{}{sluc}{it}");
+		lexer = new Lexer("\\usefont{oml}{}{sluc}{it}");
 		expect(() => parseUseFont(lexer.readToEnd()[0])).toThrow();
 
-		lexer = new LatexLexer("\\usefont{unknown}{ptm}{sluc}{it}");
+		lexer = new Lexer("\\usefont{unknown}{ptm}{sluc}{it}");
 		expect(() => parseUseFont(lexer.readToEnd()[0])).toThrow();
 	});
 });

--- a/src/ast/fonts/commands/selection.ts
+++ b/src/ast/fonts/commands/selection.ts
@@ -1,11 +1,11 @@
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	type LatexToken,
-	LatexTokenType,
+	type Token,
+	TokenType,
 } from "../../../lexer/types";
 import {
-	type LatexFont,
+	type Font,
 	type SelectionCommand,
 	type SelectionCommandFontEncoding,
 	type SelectionCommandFontFamily,
@@ -24,43 +24,38 @@ import {
 	parseToFontValue,
 } from "../utils";
 
-function parseSelectionCommands(
-	selectionCommands: SelectionCommand[],
-): LatexFont {
-	const latexFont: LatexFont = {};
+function parseSelectionCommands(selectionCommands: SelectionCommand[]): Font {
+	const Font: Font = {};
 	for (const command of selectionCommands) {
 		switch (command.type) {
 			case SelectionCommandType.Encoding:
-				latexFont.encoding = command.encoding;
+				Font.encoding = command.encoding;
 				break;
 			case SelectionCommandType.Family:
-				latexFont.family = command.family;
+				Font.family = command.family;
 				break;
 			case SelectionCommandType.Series:
-				latexFont.series = command.series;
+				Font.series = command.series;
 				break;
 			case SelectionCommandType.Shape:
-				latexFont.shape = command.shape;
+				Font.shape = command.shape;
 				break;
 			case SelectionCommandType.Size:
-				latexFont.size = command.size;
-				latexFont.baselineSkip = command.baselineSkip;
+				Font.size = command.size;
+				Font.baselineSkip = command.baselineSkip;
 				break;
 			case SelectionCommandType.LineSpread:
-				latexFont.lineSpread = command.value;
+				Font.lineSpread = command.value;
 		}
 	}
 
-	return latexFont;
+	return Font;
 }
 
-function testForOneRequiredArgument(
-	token: CommandToken,
-	type: string,
-): LatexToken {
+function testForOneRequiredArgument(token: CommandToken, type: string): Token {
 	if (
 		token.arguments.length !== 1 ||
-		token.arguments[0].type !== LatexCommandArgumentType.Required ||
+		token.arguments[0].type !== CommandArgumentType.Required ||
 		token.arguments[0].content.length !== 1
 	) {
 		throw new Error(
@@ -117,7 +112,7 @@ function parseFontShapeCommand(token: CommandToken): SelectionCommandFontShape {
 function parseFontSizeCommand(token: CommandToken): SelectionCommandFontSize {
 	if (
 		token.arguments.length !== 2 ||
-		token.arguments.every((a) => a.type !== LatexCommandArgumentType.Required)
+		token.arguments.every((a) => a.type !== CommandArgumentType.Required)
 	) {
 		throw new Error(
 			"Font size requires one required argument with two items inside",
@@ -126,8 +121,8 @@ function parseFontSizeCommand(token: CommandToken): SelectionCommandFontSize {
 
 	const [fontSizeArg, baselineSkipArg] = token.arguments;
 	if (
-		fontSizeArg.type !== LatexCommandArgumentType.Required ||
-		baselineSkipArg.type !== LatexCommandArgumentType.Required
+		fontSizeArg.type !== CommandArgumentType.Required ||
+		baselineSkipArg.type !== CommandArgumentType.Required
 	) {
 		throw new Error("");
 	}
@@ -182,20 +177,20 @@ export function parseSelectionCommandSection(
 }
 
 /** Expects the lexer to be at the backslash before the command name (e.g.. \fontsize) */
-export function parseSelectionCommandSections(tokens: LatexToken[]): LatexFont {
+export function parseSelectionCommandSections(tokens: Token[]): Font {
 	const selectionCommands: SelectionCommand[] = [];
 
 	const selectFontToken = tokens.at(-1);
 	if (
 		!selectFontToken ||
-		selectFontToken.type !== LatexTokenType.Command ||
+		selectFontToken.type !== TokenType.Command ||
 		selectFontToken.name !== "selectfont"
 	) {
 		throw new Error("Command selectfont must end a font selection sequence");
 	}
 
 	for (const token of tokens.slice(0, -1)) {
-		if (token.type !== LatexTokenType.Command) {
+		if (token.type !== TokenType.Command) {
 			continue;
 		}
 
@@ -207,12 +202,12 @@ export function parseSelectionCommandSections(tokens: LatexToken[]): LatexFont {
 }
 
 /** Expects the lexer to be at the backslash before the command name (e.g.. \usefont) */
-export function parseUseFont(token: LatexToken): LatexFont {
+export function parseUseFont(token: Token): Font {
 	if (
-		token.type !== LatexTokenType.Command ||
+		token.type !== TokenType.Command ||
 		token.name !== "usefont" ||
 		token.arguments.length !== 4 ||
-		!token.arguments.every((a) => a.type === LatexCommandArgumentType.Required)
+		!token.arguments.every((a) => a.type === CommandArgumentType.Required)
 	) {
 		throw new Error(
 			"Command must be a valid usefont command to be parsed as usefont",

--- a/src/ast/fonts/types.ts
+++ b/src/ast/fonts/types.ts
@@ -18,26 +18,24 @@ export enum FontValueType {
 	FontValue = 2,
 }
 
-export enum LatexFontEncodingType {
+export enum FontEncodingType {
 	Normal = 1,
 	Local = 2,
 }
 
-export type LatexFontEncoding = FontValue<LatexFontEncodingValue>;
-export type LatexFontEncodingValue =
-	| LatexFontEncodingLocal
-	| LatexFontEncodingNormal;
-export type LatexFontEncodingLocal = {
-	type: LatexFontEncodingType.Local;
+export type FontEncoding = FontValue<FontEncodingValue>;
+export type FontEncodingValue = FontEncodingLocal | FontEncodingNormal;
+export type FontEncodingLocal = {
+	type: FontEncodingType.Local;
 	encoding: string;
 };
 
-export type LatexFontEncodingNormal = {
-	type: LatexFontEncodingType.Normal;
-	encoding: LatexFontEncodingNormalValue;
+export type FontEncodingNormal = {
+	type: FontEncodingType.Normal;
+	encoding: FontEncodingNormalValue;
 };
 
-export enum LatexFontEncodingNormalValue {
+export enum FontEncodingNormalValue {
 	KnuthTexText = "ot1",
 	ExtendedText = "t1",
 	MathItalic = "oml",
@@ -46,14 +44,14 @@ export enum LatexFontEncodingNormalValue {
 	Unknown = "u",
 }
 
-export type LatexFontSeries = FontValue<LatexFontSeriesValue>;
-export type LatexFontSeriesValue = {
-	weight: LatexFontWeight;
-	width: LatexFontWidth;
+export type FontSeries = FontValue<FontSeriesValue>;
+export type FontSeriesValue = {
+	weight: FontWeight;
+	width: FontWidth;
 };
 
 /** corresponds to font-stretch */
-export enum LatexFontWidth {
+export enum FontWidth {
 	UltraCondensed = "uc",
 	ExtraCondensed = "ec",
 	Condensed = "c",
@@ -79,7 +77,7 @@ export enum LatexFontWidth {
  *
  * Corresponds to css font-weight
  */
-export enum LatexFontWeight {
+export enum FontWeight {
 	UltraLight = "ul",
 	ExtraLight = "el",
 	Light = "l",
@@ -91,13 +89,13 @@ export enum LatexFontWeight {
 	UltraBold = "ub",
 }
 
-export type LatexFontShape = FontValue<LatexFontShapeValue>;
+export type FontShape = FontValue<FontShapeValue>;
 /**
  * Small caps comes from font variant
  * Italic and slanted (oblique) come from font style
  * TODO: Find out what spaced caps, swash and upright italic are.
  */
-export enum LatexFontShapeValue {
+export enum FontShapeValue {
 	Normal = "n",
 	Italic = "it",
 	UprightItalic = "ui",
@@ -109,7 +107,7 @@ export enum LatexFontShapeValue {
 	SpacedCapsAndSmallCaps = "ssc",
 }
 
-export enum LatexFontSizeUnit {
+export enum FontSizeUnit {
 	Point = "pt",
 	Inch = "in",
 	Millimeter = "mm",
@@ -129,36 +127,36 @@ export enum LatexFontSizeUnit {
 	ViewportMax = "vmax",
 }
 
-export type LatexFontMeasurement = FontValue<LatexFontMeasurementValue>;
-export type LatexFontMeasurementValue = {
+export type FontMeasurement = FontValue<FontMeasurementValue>;
+export type FontMeasurementValue = {
 	value: number;
-	unit: LatexFontSizeUnit;
+	unit: FontSizeUnit;
 };
 
-export type LatexFontFamily = FontValue<LatexFontFamilyPreference | string>;
-export enum LatexFontFamilyPreference {
+export type FontFamily = FontValue<FontFamilyPreference | string>;
+export enum FontFamilyPreference {
 	PrefersSerif = "@@prefers-serif",
 	PrefersSansSerif = "@@prefers-sans-serif",
 	PrefersMonospace = "@@prefers-monospace",
 }
 
-export type LatexFontLineSpread = FontValue<number>;
+export type FontLineSpread = FontValue<number>;
 
-export type LatexFont = Partial<{
-	encoding: LatexFontEncoding;
-	family: LatexFontFamily;
-	size: LatexFontMeasurement;
-	baselineSkip: LatexFontMeasurement;
-	series: LatexFontSeries;
-	shape: LatexFontShape;
-	lineSpread: LatexFontLineSpread;
+export type Font = Partial<{
+	encoding: FontEncoding;
+	family: FontFamily;
+	size: FontMeasurement;
+	baselineSkip: FontMeasurement;
+	series: FontSeries;
+	shape: FontShape;
+	lineSpread: FontLineSpread;
 }>;
 
 // I tried to source these but couldn't find a good singular source.
 // You may want to look at https://tug.org/FontCatalogue/
 // To simplif work, we will only allow a selected amount of fonts
 // I am also not sure of how useful these are.
-export const latexFontCorrespondence: Record<string, string> = {
+export const FontCorrespondence: Record<string, string> = {
 	cm: "Computer Modern",
 	cc: "Concrete",
 	phv: "Helvetica",
@@ -189,64 +187,64 @@ export enum SelectionCommandType {
 
 export type SelectionCommandFontEncoding = {
 	type: SelectionCommandType.Encoding;
-	encoding: LatexFontEncoding;
+	encoding: FontEncoding;
 };
 
 export type SelectionCommandFontFamily = {
 	type: SelectionCommandType.Family;
-	family: LatexFontFamily;
+	family: FontFamily;
 };
 
 export type SelectionCommandFontSeries = {
 	type: SelectionCommandType.Series;
-	series: LatexFontSeries;
+	series: FontSeries;
 };
 
 export type SelectionCommandFontShape = {
 	type: SelectionCommandType.Shape;
-	shape: LatexFontShape;
+	shape: FontShape;
 };
 
 export type SelectionCommandFontSize = {
 	type: SelectionCommandType.Size;
-	size: LatexFontMeasurement;
-	baselineSkip: LatexFontMeasurement;
+	size: FontMeasurement;
+	baselineSkip: FontMeasurement;
 };
 
 export type SelectionCommandFontLineSpread = {
 	type: SelectionCommandType.LineSpread;
-	value: LatexFontLineSpread;
+	value: FontLineSpread;
 };
 
-export type LatexFontCurrentValues = Partial<{
-	encoding: LatexFontEncoding;
-	family: LatexFontFamily;
-	series: LatexFontSeries;
-	shape: LatexFontShape;
-	size: LatexFontMeasurement;
-	baselineSkip: LatexFontMeasurement;
-	mathSize: LatexFontMeasurement;
-	mathScriptSize: LatexFontMeasurement;
-	mathScriptScriptSize: LatexFontMeasurement;
+export type FontCurrentValues = Partial<{
+	encoding: FontEncoding;
+	family: FontFamily;
+	series: FontSeries;
+	shape: FontShape;
+	size: FontMeasurement;
+	baselineSkip: FontMeasurement;
+	mathSize: FontMeasurement;
+	mathScriptSize: FontMeasurement;
+	mathScriptScriptSize: FontMeasurement;
 }>;
 
-export type LatexAuthorDefaults = Partial<{
-	serif: LatexFontFamily;
-	sans: LatexFontFamily;
-	monospace: LatexFontFamily;
-	family: LatexFontFamily;
-	series: LatexFontSeries;
-	shape: LatexFontShape;
-	bold: LatexFontSeries;
-	medium: LatexFontSeries;
-	italics: LatexFontShape;
-	oblique: LatexFontShape;
-	smallCaps: LatexFontShape;
-	spacedSmallCaps: LatexFontShape;
-	swash: LatexFontShape;
-	upcase: LatexFontShape;
-	lowercase: LatexFontShape;
-	normal: LatexFont;
+export type AuthorDefaults = Partial<{
+	serif: FontFamily;
+	sans: FontFamily;
+	monospace: FontFamily;
+	family: FontFamily;
+	series: FontSeries;
+	shape: FontShape;
+	bold: FontSeries;
+	medium: FontSeries;
+	italics: FontShape;
+	oblique: FontShape;
+	smallCaps: FontShape;
+	spacedSmallCaps: FontShape;
+	swash: FontShape;
+	upcase: FontShape;
+	lowercase: FontShape;
+	normal: Font;
 }>;
 
 export enum AuthorCommandType {
@@ -257,15 +255,15 @@ export enum AuthorCommandType {
 export type AuthorCommand =
 	| {
 			type: AuthorCommandType.AuthorDefault;
-			value: keyof LatexAuthorDefaults;
+			value: keyof AuthorDefaults;
 	  }
 	| {
 			type: AuthorCommandType.FontSize;
-			value: LatexFontMeasurement;
+			value: FontMeasurement;
 	  };
 
 // Special declarations
-export type DeclareFixedFontCommand = LatexFont & { name: string };
+export type DeclareFixedFontCommand = Font & { name: string };
 export type DeclareTextFontCommand = {
 	name: string;
 	switches: AuthorCommand[];

--- a/src/ast/fonts/utils.test.ts
+++ b/src/ast/fonts/utils.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, test } from "bun:test";
 
 import {
-	LatexFontEncodingNormalValue,
-	LatexFontEncodingType,
-	type LatexFontMeasurementValue,
-	type LatexFontSeriesValue,
-	LatexFontShapeValue,
-	LatexFontSizeUnit,
-	LatexFontWeight,
-	LatexFontWidth,
+	FontEncodingNormalValue,
+	FontEncodingType,
+	type FontMeasurementValue,
+	type FontSeriesValue,
+	FontShapeValue,
+	FontSizeUnit,
+	FontWeight,
+	FontWidth,
 } from "./types";
 import {
 	parseFontEncoding,
@@ -19,25 +19,25 @@ import {
 } from "./utils";
 
 describe("parseFontEncoding", () => {
-	test.each<[LatexFontEncodingNormalValue, string]>([
-		[LatexFontEncodingNormalValue.KnuthTexText, "OT1"],
-		[LatexFontEncodingNormalValue.ExtendedText, "T1"],
-		[LatexFontEncodingNormalValue.MathItalic, "OML"],
-		[LatexFontEncodingNormalValue.MathLargeSymbols, "OMX"],
-		[LatexFontEncodingNormalValue.MathSymbols, "OMS"],
-		[LatexFontEncodingNormalValue.Unknown, "U"],
+	test.each<[FontEncodingNormalValue, string]>([
+		[FontEncodingNormalValue.KnuthTexText, "OT1"],
+		[FontEncodingNormalValue.ExtendedText, "T1"],
+		[FontEncodingNormalValue.MathItalic, "OML"],
+		[FontEncodingNormalValue.MathLargeSymbols, "OMX"],
+		[FontEncodingNormalValue.MathSymbols, "OMS"],
+		[FontEncodingNormalValue.Unknown, "U"],
 	])(
 		"should return a normal encoding of %p for an input of %s",
 		(want, input) => {
 			const got = parseFontEncoding(input);
-			expect(got.type).toEqual(LatexFontEncodingType.Normal);
+			expect(got.type).toEqual(FontEncodingType.Normal);
 			expect(got.encoding).toEqual(want);
 		},
 	);
 
 	it("should give a local encoding based on input if the first letter is L", () => {
 		const got = parseFontEncoding("LT1");
-		expect(got.type).toEqual(LatexFontEncodingType.Local);
+		expect(got.type).toEqual(FontEncodingType.Local);
 		expect(got.encoding).toEqual("LT1");
 	});
 
@@ -47,21 +47,12 @@ describe("parseFontEncoding", () => {
 });
 
 describe("parseFontSeries", () => {
-	test.each<[LatexFontSeriesValue, string]>([
-		[{ weight: LatexFontWeight.Medium, width: LatexFontWidth.Medium }, "m"],
-		[
-			{ weight: LatexFontWeight.Medium, width: LatexFontWidth.ExtraCondensed },
-			"ec",
-		],
-		[
-			{ weight: LatexFontWeight.SemiBold, width: LatexFontWidth.UltraExpanded },
-			"sbux",
-		],
-		[
-			{ weight: LatexFontWeight.UltraLight, width: LatexFontWidth.Medium },
-			"ul",
-		],
-		[{ weight: LatexFontWeight.Light, width: LatexFontWidth.Condensed }, "lc"],
+	test.each<[FontSeriesValue, string]>([
+		[{ weight: FontWeight.Medium, width: FontWidth.Medium }, "m"],
+		[{ weight: FontWeight.Medium, width: FontWidth.ExtraCondensed }, "ec"],
+		[{ weight: FontWeight.SemiBold, width: FontWidth.UltraExpanded }, "sbux"],
+		[{ weight: FontWeight.UltraLight, width: FontWidth.Medium }, "ul"],
+		[{ weight: FontWeight.Light, width: FontWidth.Condensed }, "lc"],
 	])("should return a series of %o for an input of %s", (want, input) => {
 		const got = parseFontSeries(input);
 		expect(got).toEqual(want);
@@ -73,16 +64,16 @@ describe("parseFontSeries", () => {
 });
 
 describe("parseFontShape", () => {
-	test.each<[LatexFontShapeValue, string]>([
-		[LatexFontShapeValue.CapsAndSmallCaps, "sc"],
-		[LatexFontShapeValue.CapsAndSmallCapsItalics, "scit"],
-		[LatexFontShapeValue.CapsAndSmallCapsOblique, "scsl"],
-		[LatexFontShapeValue.Italic, "it"],
-		[LatexFontShapeValue.Normal, "n"],
-		[LatexFontShapeValue.Oblique, "sl"],
-		[LatexFontShapeValue.SpacedCapsAndSmallCaps, "ssc"],
-		[LatexFontShapeValue.Swash, "sw"],
-		[LatexFontShapeValue.UprightItalic, "ui"],
+	test.each<[FontShapeValue, string]>([
+		[FontShapeValue.CapsAndSmallCaps, "sc"],
+		[FontShapeValue.CapsAndSmallCapsItalics, "scit"],
+		[FontShapeValue.CapsAndSmallCapsOblique, "scsl"],
+		[FontShapeValue.Italic, "it"],
+		[FontShapeValue.Normal, "n"],
+		[FontShapeValue.Oblique, "sl"],
+		[FontShapeValue.SpacedCapsAndSmallCaps, "ssc"],
+		[FontShapeValue.Swash, "sw"],
+		[FontShapeValue.UprightItalic, "ui"],
 	])("should return a shape of %o for an input of %s", (want, input) => {
 		const got = parseFontShape(input);
 		expect(got).toEqual(want);
@@ -94,25 +85,25 @@ describe("parseFontShape", () => {
 });
 
 describe("parseFontMeasurement;", () => {
-	test.each<[LatexFontMeasurementValue, string]>([
-		[{ value: 1, unit: LatexFontSizeUnit.Point }, "1"],
-		[{ value: 10, unit: LatexFontSizeUnit.Point }, "10pt"],
-		[{ value: 11.2, unit: LatexFontSizeUnit.Cicero }, "11.2cc"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.BigPoint }, "123.4bp"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Centimeter }, "123.4cm"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Millimeter }, "123.4mm"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.DidotPoint }, "123.4dd"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Em }, "123.4em"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Ex }, "123.4ex"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Inch }, "123.4in"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Mu }, "123.4mu"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Pica }, "123.4pc"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.Pixel }, "123.4px"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.ScaledPoint }, "123.4sp"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.ViewportHeight }, "123.4vh"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.ViewportWidth }, "123.4vw"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.ViewportMin }, "123.4vmin"],
-		[{ value: 123.4, unit: LatexFontSizeUnit.ViewportMax }, "123.4vmax"],
+	test.each<[FontMeasurementValue, string]>([
+		[{ value: 1, unit: FontSizeUnit.Point }, "1"],
+		[{ value: 10, unit: FontSizeUnit.Point }, "10pt"],
+		[{ value: 11.2, unit: FontSizeUnit.Cicero }, "11.2cc"],
+		[{ value: 123.4, unit: FontSizeUnit.BigPoint }, "123.4bp"],
+		[{ value: 123.4, unit: FontSizeUnit.Centimeter }, "123.4cm"],
+		[{ value: 123.4, unit: FontSizeUnit.Millimeter }, "123.4mm"],
+		[{ value: 123.4, unit: FontSizeUnit.DidotPoint }, "123.4dd"],
+		[{ value: 123.4, unit: FontSizeUnit.Em }, "123.4em"],
+		[{ value: 123.4, unit: FontSizeUnit.Ex }, "123.4ex"],
+		[{ value: 123.4, unit: FontSizeUnit.Inch }, "123.4in"],
+		[{ value: 123.4, unit: FontSizeUnit.Mu }, "123.4mu"],
+		[{ value: 123.4, unit: FontSizeUnit.Pica }, "123.4pc"],
+		[{ value: 123.4, unit: FontSizeUnit.Pixel }, "123.4px"],
+		[{ value: 123.4, unit: FontSizeUnit.ScaledPoint }, "123.4sp"],
+		[{ value: 123.4, unit: FontSizeUnit.ViewportHeight }, "123.4vh"],
+		[{ value: 123.4, unit: FontSizeUnit.ViewportWidth }, "123.4vw"],
+		[{ value: 123.4, unit: FontSizeUnit.ViewportMin }, "123.4vmin"],
+		[{ value: 123.4, unit: FontSizeUnit.ViewportMax }, "123.4vmax"],
 	])("should return a measurement of %o for an input of %s", (want, input) => {
 		const got = parseFontMeasurement(input);
 		expect(got).toEqual(want);

--- a/src/ast/fonts/utils.ts
+++ b/src/ast/fonts/utils.ts
@@ -1,56 +1,56 @@
-import { type LatexToken, LatexTokenType } from "../../lexer/types";
+import { type Token, TokenType } from "../../lexer/types";
 import {
+	type FontEncodingLocal,
+	FontEncodingNormalValue,
+	FontEncodingType,
+	type FontEncodingValue,
+	type FontMeasurementValue,
+	type FontSeriesValue,
+	FontShapeValue,
+	FontSizeUnit,
 	type FontValue,
 	FontValueType,
-	type LatexFontEncodingLocal,
-	LatexFontEncodingNormalValue,
-	LatexFontEncodingType,
-	type LatexFontEncodingValue,
-	type LatexFontMeasurementValue,
-	type LatexFontSeriesValue,
-	LatexFontShapeValue,
-	LatexFontSizeUnit,
-	LatexFontWeight,
-	LatexFontWidth,
+	FontWeight,
+	FontWidth,
 } from "./types";
 
-export function parseFontEncoding(rawCommand: string): LatexFontEncodingValue {
+export function parseFontEncoding(rawCommand: string): FontEncodingValue {
 	if (rawCommand.toLocaleUpperCase().startsWith("L")) {
-		const fontEncoding: LatexFontEncodingLocal = {
-			type: LatexFontEncodingType.Local,
+		const fontEncoding: FontEncodingLocal = {
+			type: FontEncodingType.Local,
 			encoding: rawCommand,
 		};
 
 		return fontEncoding;
 	}
 
-	let encoding: LatexFontEncodingNormalValue;
+	let encoding: FontEncodingNormalValue;
 
 	switch (rawCommand.toLocaleUpperCase()) {
 		case "OT1":
-			encoding = LatexFontEncodingNormalValue.KnuthTexText;
+			encoding = FontEncodingNormalValue.KnuthTexText;
 			break;
 		case "T1":
-			encoding = LatexFontEncodingNormalValue.ExtendedText;
+			encoding = FontEncodingNormalValue.ExtendedText;
 			break;
 		case "OML":
-			encoding = LatexFontEncodingNormalValue.MathItalic;
+			encoding = FontEncodingNormalValue.MathItalic;
 			break;
 		case "OMS":
-			encoding = LatexFontEncodingNormalValue.MathSymbols;
+			encoding = FontEncodingNormalValue.MathSymbols;
 			break;
 		case "OMX":
-			encoding = LatexFontEncodingNormalValue.MathLargeSymbols;
+			encoding = FontEncodingNormalValue.MathLargeSymbols;
 			break;
 		case "U":
-			encoding = LatexFontEncodingNormalValue.Unknown;
+			encoding = FontEncodingNormalValue.Unknown;
 			break;
 		default:
 			throw new Error(`Unrecognized encoding value: ${rawCommand}`);
 	}
 
 	const fontEncoding = {
-		type: LatexFontEncodingType.Normal,
+		type: FontEncodingType.Normal,
 		encoding,
 	};
 
@@ -66,10 +66,10 @@ export function parseFontFamily(rawCommand: string): string {
 
 const FONT_SERIES_RE = /^([ues]?[lb])?([ues]?[cx])?$/;
 // TODO: Decide error handling and unknown values.
-export function parseFontSeries(rawCommand: string): LatexFontSeriesValue {
+export function parseFontSeries(rawCommand: string): FontSeriesValue {
 	const series = {
-		weight: LatexFontWeight.Medium,
-		width: LatexFontWidth.Medium,
+		weight: FontWeight.Medium,
+		width: FontWidth.Medium,
 	};
 	if (rawCommand === "m") {
 		return series;
@@ -89,28 +89,28 @@ export function parseFontSeries(rawCommand: string): LatexFontSeriesValue {
 	if (rawWeight) {
 		switch (rawWeight.toLocaleLowerCase()) {
 			case "ul":
-				series.weight = LatexFontWeight.UltraLight;
+				series.weight = FontWeight.UltraLight;
 				break;
 			case "el":
-				series.weight = LatexFontWeight.ExtraLight;
+				series.weight = FontWeight.ExtraLight;
 				break;
 			case "l":
-				series.weight = LatexFontWeight.Light;
+				series.weight = FontWeight.Light;
 				break;
 			case "sl":
-				series.weight = LatexFontWeight.SemiLight;
+				series.weight = FontWeight.SemiLight;
 				break;
 			case "sb":
-				series.weight = LatexFontWeight.SemiBold;
+				series.weight = FontWeight.SemiBold;
 				break;
 			case "b":
-				series.weight = LatexFontWeight.Bold;
+				series.weight = FontWeight.Bold;
 				break;
 			case "eb":
-				series.weight = LatexFontWeight.ExtraBold;
+				series.weight = FontWeight.ExtraBold;
 				break;
 			case "ub":
-				series.weight = LatexFontWeight.UltraBold;
+				series.weight = FontWeight.UltraBold;
 				break;
 			default:
 				throw new Error(`Unrecognized weight: ${rawWeight}`);
@@ -120,28 +120,28 @@ export function parseFontSeries(rawCommand: string): LatexFontSeriesValue {
 	if (rawWidth) {
 		switch (rawWidth.toLocaleLowerCase()) {
 			case "uc":
-				series.width = LatexFontWidth.UltraCondensed;
+				series.width = FontWidth.UltraCondensed;
 				break;
 			case "ec":
-				series.width = LatexFontWidth.ExtraCondensed;
+				series.width = FontWidth.ExtraCondensed;
 				break;
 			case "c":
-				series.width = LatexFontWidth.Condensed;
+				series.width = FontWidth.Condensed;
 				break;
 			case "sc":
-				series.width = LatexFontWidth.SemiCondensed;
+				series.width = FontWidth.SemiCondensed;
 				break;
 			case "sx":
-				series.width = LatexFontWidth.SemiExpanded;
+				series.width = FontWidth.SemiExpanded;
 				break;
 			case "x":
-				series.width = LatexFontWidth.Expanded;
+				series.width = FontWidth.Expanded;
 				break;
 			case "ex":
-				series.width = LatexFontWidth.ExtraExpanded;
+				series.width = FontWidth.ExtraExpanded;
 				break;
 			case "ux":
-				series.width = LatexFontWidth.UltraExpanded;
+				series.width = FontWidth.UltraExpanded;
 				break;
 			default:
 				throw new Error(`Unrecognized width: ${rawWidth}`);
@@ -151,26 +151,26 @@ export function parseFontSeries(rawCommand: string): LatexFontSeriesValue {
 	return series;
 }
 
-export function parseFontShape(rawCommand: string): LatexFontShapeValue {
+export function parseFontShape(rawCommand: string): FontShapeValue {
 	switch (rawCommand.toLocaleLowerCase()) {
 		case "n":
-			return LatexFontShapeValue.Normal;
+			return FontShapeValue.Normal;
 		case "it":
-			return LatexFontShapeValue.Italic;
+			return FontShapeValue.Italic;
 		case "sl":
-			return LatexFontShapeValue.Oblique;
+			return FontShapeValue.Oblique;
 		case "sc":
-			return LatexFontShapeValue.CapsAndSmallCaps;
+			return FontShapeValue.CapsAndSmallCaps;
 		case "scit":
-			return LatexFontShapeValue.CapsAndSmallCapsItalics;
+			return FontShapeValue.CapsAndSmallCapsItalics;
 		case "scsl":
-			return LatexFontShapeValue.CapsAndSmallCapsOblique;
+			return FontShapeValue.CapsAndSmallCapsOblique;
 		case "sw":
-			return LatexFontShapeValue.Swash;
+			return FontShapeValue.Swash;
 		case "ssc":
-			return LatexFontShapeValue.SpacedCapsAndSmallCaps;
+			return FontShapeValue.SpacedCapsAndSmallCaps;
 		case "ui":
-			return LatexFontShapeValue.UprightItalic;
+			return FontShapeValue.UprightItalic;
 		default:
 			throw new Error(`Unrecognized font shape: ${rawCommand}`);
 	}
@@ -184,7 +184,7 @@ const FONT_SIZE_RE =
 	/^([0-9]+)(\.[0-9]+)?(pt|mm|cm|in|ex|em|mu|sp|vmin|vmax|vh|vw|cc|bp|dd|pc|px)?$/;
 export function parseFontMeasurement(
 	rawMeasurement: string,
-): LatexFontMeasurementValue {
+): FontMeasurementValue {
 	const matches = rawMeasurement.match(FONT_SIZE_RE);
 	if (!matches || matches.length !== 4) {
 		throw new Error(`Unrecognized font measurement: ${rawMeasurement}`);
@@ -199,57 +199,57 @@ export function parseFontMeasurement(
 	return { value, unit };
 }
 
-function parseFontSizeUnit(rawUnit?: string): LatexFontSizeUnit {
+function parseFontSizeUnit(rawUnit?: string): FontSizeUnit {
 	switch (rawUnit) {
 		case "in":
-			return LatexFontSizeUnit.Inch;
+			return FontSizeUnit.Inch;
 		case "mm":
-			return LatexFontSizeUnit.Millimeter;
+			return FontSizeUnit.Millimeter;
 		case "cm":
-			return LatexFontSizeUnit.Centimeter;
+			return FontSizeUnit.Centimeter;
 		case "pc":
-			return LatexFontSizeUnit.Pica;
+			return FontSizeUnit.Pica;
 		case "dd":
-			return LatexFontSizeUnit.DidotPoint;
+			return FontSizeUnit.DidotPoint;
 		case "cc":
-			return LatexFontSizeUnit.Cicero;
+			return FontSizeUnit.Cicero;
 		case "sp":
-			return LatexFontSizeUnit.ScaledPoint;
+			return FontSizeUnit.ScaledPoint;
 		case "bp":
-			return LatexFontSizeUnit.BigPoint;
+			return FontSizeUnit.BigPoint;
 		case "em":
-			return LatexFontSizeUnit.Em;
+			return FontSizeUnit.Em;
 		case "ex":
-			return LatexFontSizeUnit.Ex;
+			return FontSizeUnit.Ex;
 		case "mu":
-			return LatexFontSizeUnit.Mu;
+			return FontSizeUnit.Mu;
 		case "px":
-			return LatexFontSizeUnit.Pixel;
+			return FontSizeUnit.Pixel;
 		case "vh":
-			return LatexFontSizeUnit.ViewportHeight;
+			return FontSizeUnit.ViewportHeight;
 		case "vw":
-			return LatexFontSizeUnit.ViewportWidth;
+			return FontSizeUnit.ViewportWidth;
 		case "vmin":
-			return LatexFontSizeUnit.ViewportMin;
+			return FontSizeUnit.ViewportMin;
 		case "vmax":
-			return LatexFontSizeUnit.ViewportMax;
+			return FontSizeUnit.ViewportMax;
 		default:
-			return LatexFontSizeUnit.Point;
+			return FontSizeUnit.Point;
 	}
 }
 
 export function parseToFontValue<T>(
-	token: LatexToken,
+	token: Token,
 	callback: (value: string) => T,
 ): FontValue<T> {
-	if (token.type === LatexTokenType.Command) {
+	if (token.type === TokenType.Command) {
 		return {
 			type: FontValueType.CommandToken,
 			value: token,
 		};
 	}
 
-	if (token.type === LatexTokenType.Content) {
+	if (token.type === TokenType.Content) {
 		return {
 			type: FontValueType.FontValue,
 			value: callback(token.literal.trim()),

--- a/src/ast/math/correspondence.ts
+++ b/src/ast/math/correspondence.ts
@@ -1,20 +1,20 @@
 import {
+	type Font,
+	FontEncodingNormalValue,
+	FontEncodingType,
+	FontShapeValue,
 	FontValueType,
-	type LatexFont,
-	LatexFontEncodingNormalValue,
-	LatexFontEncodingType,
-	LatexFontShapeValue,
-	LatexFontWeight,
-	LatexFontWidth,
+	FontWeight,
+	FontWidth,
 } from "../fonts/types";
 import { MathFont, MathSymbolFont } from "./types";
 
-const mathNormalCorrespondence: LatexFont = {
+const mathNormalCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.MathItalic,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.MathItalic,
 		},
 	},
 	family: {
@@ -24,22 +24,22 @@ const mathNormalCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Medium,
-			width: LatexFontWidth.Medium,
+			weight: FontWeight.Medium,
+			width: FontWidth.Medium,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Italic,
+		value: FontShapeValue.Italic,
 	},
 };
 
-const mathSerifCorrespondence: LatexFont = {
+const mathSerifCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.KnuthTexText,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.KnuthTexText,
 		},
 	},
 	family: {
@@ -49,22 +49,22 @@ const mathSerifCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Medium,
-			width: LatexFontWidth.Medium,
+			weight: FontWeight.Medium,
+			width: FontWidth.Medium,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Normal,
+		value: FontShapeValue.Normal,
 	},
 };
 
-const mathCalligraphicSymbolsCorrespondence: LatexFont = {
+const mathCalligraphicSymbolsCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.MathSymbols,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.MathSymbols,
 		},
 	},
 	family: {
@@ -74,22 +74,22 @@ const mathCalligraphicSymbolsCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Medium,
-			width: LatexFontWidth.Medium,
+			weight: FontWeight.Medium,
+			width: FontWidth.Medium,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Normal,
+		value: FontShapeValue.Normal,
 	},
 };
 
-const mathCalligraphicLargeSymbolsCorrespondence: LatexFont = {
+const mathCalligraphicLargeSymbolsCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.MathLargeSymbols,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.MathLargeSymbols,
 		},
 	},
 	family: {
@@ -99,22 +99,22 @@ const mathCalligraphicLargeSymbolsCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Medium,
-			width: LatexFontWidth.Medium,
+			weight: FontWeight.Medium,
+			width: FontWidth.Medium,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Normal,
+		value: FontShapeValue.Normal,
 	},
 };
 
-const mathBoldFontCorrespondence: LatexFont = {
+const mathBoldFontCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.KnuthTexText,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.KnuthTexText,
 		},
 	},
 	family: {
@@ -124,22 +124,22 @@ const mathBoldFontCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Bold,
-			width: LatexFontWidth.Expanded,
+			weight: FontWeight.Bold,
+			width: FontWidth.Expanded,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Normal,
+		value: FontShapeValue.Normal,
 	},
 };
 
-const mathSansSerifCorrespondence: LatexFont = {
+const mathSansSerifCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.KnuthTexText,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.KnuthTexText,
 		},
 	},
 	family: {
@@ -149,22 +149,22 @@ const mathSansSerifCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Medium,
-			width: LatexFontWidth.Medium,
+			weight: FontWeight.Medium,
+			width: FontWidth.Medium,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Normal,
+		value: FontShapeValue.Normal,
 	},
 };
 
-const mathItalicsCorrespondence: LatexFont = {
+const mathItalicsCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.KnuthTexText,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.KnuthTexText,
 		},
 	},
 	family: {
@@ -174,22 +174,22 @@ const mathItalicsCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Medium,
-			width: LatexFontWidth.Medium,
+			weight: FontWeight.Medium,
+			width: FontWidth.Medium,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Italic,
+		value: FontShapeValue.Italic,
 	},
 };
 
-const mathTypewriterCorrespondence: LatexFont = {
+const mathTypewriterCorrespondence: Font = {
 	encoding: {
 		type: FontValueType.FontValue,
 		value: {
-			type: LatexFontEncodingType.Normal,
-			encoding: LatexFontEncodingNormalValue.KnuthTexText,
+			type: FontEncodingType.Normal,
+			encoding: FontEncodingNormalValue.KnuthTexText,
 		},
 	},
 	family: {
@@ -199,13 +199,13 @@ const mathTypewriterCorrespondence: LatexFont = {
 	series: {
 		type: FontValueType.FontValue,
 		value: {
-			weight: LatexFontWeight.Medium,
-			width: LatexFontWidth.Medium,
+			weight: FontWeight.Medium,
+			width: FontWidth.Medium,
 		},
 	},
 	shape: {
 		type: FontValueType.FontValue,
-		value: LatexFontShapeValue.Normal,
+		value: FontShapeValue.Normal,
 	},
 };
 
@@ -223,7 +223,7 @@ export const fontCorrespondence = {
 export function getMathCorrespondenceFont(
 	name: MathFont,
 	isLargeSymbols = false,
-): LatexFont | null {
+): Font | null {
 	switch (name) {
 		case MathFont.Normal:
 			return fontCorrespondence.normal;
@@ -248,7 +248,7 @@ export function getMathCorrespondenceFont(
 
 export function getMathSymbolsCorrespondenceFont(
 	name: MathSymbolFont,
-): LatexFont | null {
+): Font | null {
 	switch (name) {
 		case MathSymbolFont.Letters:
 			return fontCorrespondence.normal;

--- a/src/ast/math/declaration.test.ts
+++ b/src/ast/math/declaration.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it, test } from "bun:test";
 
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	LatexTokenType,
+	TokenType,
 } from "../../lexer/types";
 import {
+	FontEncodingNormalValue,
+	FontEncodingType,
+	FontShapeValue,
 	FontValueType,
-	LatexFontEncodingNormalValue,
-	LatexFontEncodingType,
-	LatexFontShapeValue,
 } from "../fonts/types";
 import {
 	declareMathOrSymbolAlphabet,
@@ -29,13 +29,13 @@ describe("declareMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
@@ -52,7 +52,7 @@ describe("declareMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 
@@ -64,23 +64,23 @@ describe("declareMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "bold",
 							originalLength: 4,
 						},
@@ -97,10 +97,10 @@ describe("declareMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: [],
 				},
 			],
@@ -114,18 +114,18 @@ describe("declareMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "bold",
 							originalLength: 4,
 						},
@@ -142,13 +142,13 @@ describe("declareMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\normal",
 							name: "normal",
 							arguments: [],
@@ -168,7 +168,7 @@ describe("declareMathOrSymbolAlphabet", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 
@@ -180,22 +180,22 @@ describe("declareMathOrSymbolAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareMathAlphabet",
 			literal: "\\DeclareMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 			],
@@ -209,58 +209,58 @@ describe("declareMathOrSymbolAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareMathAlphabet",
 			literal: "\\DeclareMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "argument1",
 							originalLength: 9,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "extraToken",
 							originalLength: 10,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "argument2",
 							originalLength: 9,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "argument3",
 							originalLength: 9,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "argument4",
 							originalLength: 9,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "argument5",
 							originalLength: 9,
 						},
@@ -277,13 +277,13 @@ describe("declareMathOrSymbolAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareMathAlphabet",
 			literal: "\\DeclareMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\mathfontname",
 							name: "mathfontname",
 							arguments: [],
@@ -291,24 +291,24 @@ describe("declareMathOrSymbolAlphabet", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "OT1",
 							originalLength: 38,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\coolcommand",
 							name: "coolcommand",
 							arguments: [],
@@ -316,10 +316,10 @@ describe("declareMathOrSymbolAlphabet", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "it",
 							originalLength: 2,
 						},
@@ -336,8 +336,8 @@ describe("declareMathOrSymbolAlphabet", () => {
 				value: {
 					type: FontValueType.FontValue,
 					value: {
-						type: LatexFontEncodingType.Normal,
-						encoding: LatexFontEncodingNormalValue.KnuthTexText,
+						type: FontEncodingType.Normal,
+						encoding: FontEncodingNormalValue.KnuthTexText,
 					},
 				},
 			},
@@ -349,7 +349,7 @@ describe("declareMathOrSymbolAlphabet", () => {
 				value: {
 					type: FontValueType.CommandToken,
 					value: {
-						type: LatexTokenType.Command,
+						type: TokenType.Command,
 						literal: "\\coolcommand",
 						name: "coolcommand",
 						arguments: [],
@@ -360,7 +360,7 @@ describe("declareMathOrSymbolAlphabet", () => {
 				type: MathAlphabetDeclarationType.Set,
 				value: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 		});
@@ -372,7 +372,7 @@ describe("setMathOrSymbolFont", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 		const result = setMathOrSymbolFont(command);
@@ -383,26 +383,26 @@ describe("setMathOrSymbolFont", () => {
 		const command: CommandToken = {
 			name: "SetMathAlphabet",
 			literal: "\\SetMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 			],
@@ -415,26 +415,26 @@ describe("setMathOrSymbolFont", () => {
 		const command: CommandToken = {
 			name: "SetMathAlphabet",
 			literal: "\\SetMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: [],
 				},
 			],
@@ -447,41 +447,41 @@ describe("setMathOrSymbolFont", () => {
 		const command: CommandToken = {
 			name: "SetMathAlphabet",
 			literal: "\\SetMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "version",
 							originalLength: 7,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "extraToken",
 							originalLength: 10,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 			],
@@ -494,13 +494,13 @@ describe("setMathOrSymbolFont", () => {
 		const command: CommandToken = {
 			name: "SetMathAlphabet",
 			literal: "\\SetMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\mathfontname",
 							name: "mathfontname",
 							arguments: [],
@@ -508,34 +508,34 @@ describe("setMathOrSymbolFont", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Placeholder,
+							type: TokenType.Placeholder,
 							literal: "#1",
 							content: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\coolcommand",
 							name: "coolcommand",
 							arguments: [],
@@ -543,10 +543,10 @@ describe("setMathOrSymbolFont", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "it",
 							originalLength: 2,
 						},
@@ -561,13 +561,13 @@ describe("setMathOrSymbolFont", () => {
 		const command: CommandToken = {
 			name: "SetMathAlphabet",
 			literal: "\\SetMathAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\mathfontname",
 							name: "mathfontname",
 							arguments: [],
@@ -575,34 +575,34 @@ describe("setMathOrSymbolFont", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "OT1",
 							originalLength: 3,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\coolcommand",
 							name: "coolcommand",
 							arguments: [],
@@ -610,10 +610,10 @@ describe("setMathOrSymbolFont", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "it",
 							originalLength: 2,
 						},
@@ -630,8 +630,8 @@ describe("setMathOrSymbolFont", () => {
 				value: {
 					type: FontValueType.FontValue,
 					value: {
-						type: LatexFontEncodingType.Normal,
-						encoding: LatexFontEncodingNormalValue.KnuthTexText,
+						type: FontEncodingType.Normal,
+						encoding: FontEncodingNormalValue.KnuthTexText,
 					},
 				},
 			},
@@ -643,7 +643,7 @@ describe("setMathOrSymbolFont", () => {
 				value: {
 					type: FontValueType.CommandToken,
 					value: {
-						type: LatexTokenType.Command,
+						type: TokenType.Command,
 						literal: "\\coolcommand",
 						name: "coolcommand",
 						arguments: [],
@@ -654,7 +654,7 @@ describe("setMathOrSymbolFont", () => {
 				type: MathAlphabetDeclarationType.Set,
 				value: {
 					type: FontValueType.FontValue,
-					value: LatexFontShapeValue.Italic,
+					value: FontShapeValue.Italic,
 				},
 			},
 		});
@@ -665,7 +665,7 @@ describe("declareSymbolFontAlphabet", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 
@@ -677,10 +677,10 @@ describe("declareSymbolFontAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareSymbolFontAlphabet",
 			literal: "\\DeclareSymbolFontAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 			],
@@ -694,28 +694,28 @@ describe("declareSymbolFontAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareSymbolFontAlphabet",
 			literal: "\\DeclareSymbolFontAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "argument1",
 							originalLength: 9,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "extraToken",
 							originalLength: 10,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "argument2",
 							originalLength: 9,
 						},
@@ -732,13 +732,13 @@ describe("declareSymbolFontAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareSymbolFontAlphabet",
 			literal: "\\DeclareSymbolFontAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\invalidalphabet",
 							name: "invalidalphabet",
 							arguments: [],
@@ -746,10 +746,10 @@ describe("declareSymbolFontAlphabet", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "fontname",
 							originalLength: 8,
 						},
@@ -766,13 +766,13 @@ describe("declareSymbolFontAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareSymbolFontAlphabet",
 			literal: "\\DeclareSymbolFontAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\validalphabet",
 							name: "validalphabet",
 							arguments: [],
@@ -780,10 +780,10 @@ describe("declareSymbolFontAlphabet", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "invalidfont",
 							originalLength: 10,
 						},
@@ -804,13 +804,13 @@ describe("declareSymbolFontAlphabet", () => {
 		const command: CommandToken = {
 			name: "DeclareSymbolFontAlphabet",
 			literal: "\\DeclareSymbolFontAlphabet",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Command,
+							type: TokenType.Command,
 							literal: "\\validalphabet",
 							name: "validalphabet",
 							arguments: [],
@@ -818,10 +818,10 @@ describe("declareSymbolFontAlphabet", () => {
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "validfont",
 							originalLength: 9,
 						},
@@ -905,13 +905,13 @@ describe("declareSymbolFontAlphabet", () => {
 			const command: CommandToken = {
 				name: "DeclareSymbolFontAlphabet",
 				literal: "\\DeclareSymbolFontAlphabet",
-				type: LatexTokenType.Command,
+				type: TokenType.Command,
 				arguments: [
 					{
-						type: LatexCommandArgumentType.Required,
+						type: CommandArgumentType.Required,
 						content: [
 							{
-								type: LatexTokenType.Command,
+								type: TokenType.Command,
 								literal: `\\${mathAlphabet}`,
 								name: mathAlphabet,
 								arguments: [],
@@ -919,10 +919,10 @@ describe("declareSymbolFontAlphabet", () => {
 						],
 					},
 					{
-						type: LatexCommandArgumentType.Required,
+						type: CommandArgumentType.Required,
 						content: [
 							{
-								type: LatexTokenType.Content,
+								type: TokenType.Content,
 								literal: symbolFont,
 								originalLength: symbolFont.length,
 							},

--- a/src/ast/math/declaration.ts
+++ b/src/ast/math/declaration.ts
@@ -1,8 +1,8 @@
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	type LatexToken,
-	LatexTokenType,
+	type Token,
+	TokenType,
 } from "../../lexer/types";
 import type { FontValue } from "../fonts/types";
 import {
@@ -25,9 +25,9 @@ import {
 export function declareMathVersion(command: CommandToken): string | null {
 	if (
 		command.arguments.length !== 1 ||
-		command.arguments[0].type !== LatexCommandArgumentType.Required ||
+		command.arguments[0].type !== CommandArgumentType.Required ||
 		command.arguments[0].content.length !== 1 ||
-		command.arguments[0].content[0].type !== LatexTokenType.Content
+		command.arguments[0].content[0].type !== TokenType.Content
 	) {
 		return null;
 	}
@@ -38,7 +38,7 @@ export function declareMathVersion(command: CommandToken): string | null {
 }
 
 function parsePossibleToken<T>(
-	token: LatexToken | undefined,
+	token: Token | undefined,
 	callback: (token: string) => T,
 ): MathAlphabetDeclarationValue<FontValue<T>> {
 	if (!token) {
@@ -55,10 +55,10 @@ function parsePossibleToken<T>(
 }
 
 function parseAlphabetDeclarationTokens(
-	encodingToken: LatexToken | undefined,
-	familyToken: LatexToken | undefined,
-	seriesToken: LatexToken | undefined,
-	shapeToken: LatexToken | undefined,
+	encodingToken: Token | undefined,
+	familyToken: Token | undefined,
+	seriesToken: Token | undefined,
+	shapeToken: Token | undefined,
 ): MathAlphabetBase {
 	const encoding = parsePossibleToken(encodingToken, parseFontEncoding);
 	const family = parsePossibleToken(familyToken, parseFontFamily);
@@ -78,17 +78,16 @@ export function declareMathOrSymbolAlphabet(
 		command.arguments.length !== 5 ||
 		command.arguments.every(
 			(arg) =>
-				arg.type !== LatexCommandArgumentType.Required ||
-				arg.content.length > 1,
+				arg.type !== CommandArgumentType.Required || arg.content.length > 1,
 		)
 	) {
 		return null;
 	}
 
 	const [nameToken, encodingToken, familyToken, seriesToken, shapeToken] =
-		command.arguments.map((arg) => (arg.content as LatexToken[]).at(0));
+		command.arguments.map((arg) => (arg.content as Token[]).at(0));
 
-	if (!nameToken || nameToken.type !== LatexTokenType.Command) {
+	if (!nameToken || nameToken.type !== TokenType.Command) {
 		return null;
 	}
 
@@ -111,9 +110,7 @@ export function setMathOrSymbolFont(
 	if (
 		(command.name !== "SetMathAlphabet" && command.name !== "SetSymbolFont") ||
 		command.arguments.length !== 6 ||
-		command.arguments.every(
-			(arg) => arg.type !== LatexCommandArgumentType.Required,
-		)
+		command.arguments.every((arg) => arg.type !== CommandArgumentType.Required)
 	) {
 		return null;
 	}
@@ -125,11 +122,11 @@ export function setMathOrSymbolFont(
 		familyToken,
 		seriesToken,
 		shapeToken,
-	] = command.arguments.map((arg) => (arg.content as LatexToken[]).at(0));
+	] = command.arguments.map((arg) => (arg.content as Token[]).at(0));
 
 	if (
 		!nameToken ||
-		nameToken.type !== LatexTokenType.Command ||
+		nameToken.type !== TokenType.Command ||
 		nameToken.arguments.length > 0
 	) {
 		return null;
@@ -137,7 +134,7 @@ export function setMathOrSymbolFont(
 
 	const { name } = nameToken;
 
-	if (!versionToken || versionToken.type !== LatexTokenType.Content) {
+	if (!versionToken || versionToken.type !== TokenType.Content) {
 		return null;
 	}
 
@@ -165,24 +162,23 @@ export function declareSymbolFontAlphabet(
 		command.arguments.length !== 2 ||
 		command.arguments.every(
 			(arg) =>
-				arg.type !== LatexCommandArgumentType.Required ||
-				arg.content.length > 1,
+				arg.type !== CommandArgumentType.Required || arg.content.length > 1,
 		)
 	) {
 		return null;
 	}
 
 	const [mathAlphabet, symbolFont] = command.arguments.map((arg) =>
-		(arg.content as LatexToken[]).at(0),
+		(arg.content as Token[]).at(0),
 	);
 
-	if (!mathAlphabet || mathAlphabet.type !== LatexTokenType.Command) {
+	if (!mathAlphabet || mathAlphabet.type !== TokenType.Command) {
 		return null;
 	}
 
 	const alphabetName = mathAlphabet.name;
 
-	if (!symbolFont || symbolFont.type !== LatexTokenType.Content) {
+	if (!symbolFont || symbolFont.type !== TokenType.Content) {
 		return null;
 	}
 

--- a/src/ast/math/selection.test.ts
+++ b/src/ast/math/selection.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	LatexTokenType,
+	TokenType,
 } from "../../lexer/types";
 import { isMathSelection, isMathVersion } from "./selection";
 import { MathFont } from "./types";
@@ -32,23 +32,23 @@ describe("isMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
@@ -65,13 +65,13 @@ describe("isMathVersion", () => {
 		const command: CommandToken = {
 			name: "mathversion",
 			literal: "\\mathversion",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "normal",
 							originalLength: 6,
 						},
@@ -88,7 +88,7 @@ describe("isMathVersion", () => {
 		let command: CommandToken = {
 			name: "normalmath",
 			literal: "\\normalmath",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 
@@ -98,7 +98,7 @@ describe("isMathVersion", () => {
 		command = {
 			name: "boldmath",
 			literal: "\\boldmath",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 
@@ -110,7 +110,7 @@ describe("isMathVersion", () => {
 		const command: CommandToken = {
 			name: "coolmath",
 			literal: "\\coolmath",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 
@@ -122,7 +122,7 @@ describe("isMathVersion", () => {
 		const command: CommandToken = {
 			name: "coolmath",
 			literal: "\\coolmath",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 

--- a/src/ast/math/symbols.test.ts
+++ b/src/ast/math/symbols.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, test } from "bun:test";
 
 import {
+	CommandArgumentType,
 	type CommandToken,
-	LatexCommandArgumentType,
-	type LatexToken,
-	LatexTokenType,
+	type Token,
+	TokenType,
 } from "../../lexer/types";
-import { LatexFontSizeUnit } from "../fonts/types";
+import { FontSizeUnit } from "../fonts/types";
 import {
 	declareMathAccent,
 	declareMathDelimiter,
@@ -41,16 +41,16 @@ describe("getMathSymbolType", () => {
 		[MathSymbolType.AlphabetChar, "7"],
 		[MathSymbolType.AlphabetChar, "mathalpha"],
 	])("should return %s for input %s", (want, input) => {
-		let token: LatexToken;
+		let token: Token;
 		if (input.length === 1) {
 			token = {
-				type: LatexTokenType.Content,
+				type: TokenType.Content,
 				literal: input,
 				originalLength: 1,
 			};
 		} else {
 			token = {
-				type: LatexTokenType.Command,
+				type: TokenType.Command,
 				name: input,
 				literal: `\\${input}`,
 				arguments: [],
@@ -62,7 +62,7 @@ describe("getMathSymbolType", () => {
 
 	it("should return null for an unrecognized command", () => {
 		const got = getMathSymbolType({
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			name: "unknown",
 			literal: "\\unknown",
 			arguments: [],
@@ -72,17 +72,17 @@ describe("getMathSymbolType", () => {
 
 	it("should return null for a command token that's not a simple macro", () => {
 		const got = getMathSymbolType({
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			name: "mathrel",
 			literal: "\\mathrel",
-			arguments: [{ type: LatexCommandArgumentType.Required, content: [] }],
+			arguments: [{ type: CommandArgumentType.Required, content: [] }],
 		});
 		expect(got).toBeNull();
 	});
 
 	it("should return null for a content token with an unrecognized value", () => {
 		const got = getMathSymbolType({
-			type: LatexTokenType.Content,
+			type: TokenType.Content,
 			literal: "unknown",
 			originalLength: 7,
 		});
@@ -91,7 +91,7 @@ describe("getMathSymbolType", () => {
 
 	it("should return null for a token that's not content or a command", () => {
 		const got = getMathSymbolType({
-			type: LatexTokenType.Placeholder,
+			type: TokenType.Placeholder,
 			literal: "#1",
 			content: 1,
 		});
@@ -104,43 +104,43 @@ describe("declareMathSymbol", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -156,7 +156,7 @@ describe("declareMathSymbol", () => {
 		const command: CommandToken = {
 			name: "DeclareMathSymbol",
 			literal: "\\DeclareMathSymbol",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 		const got = declareMathSymbol(command);
@@ -168,46 +168,46 @@ describe("declareMathSymbol", () => {
 			name: "DeclareMathSymbol",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: {
-						type: LatexTokenType.Content,
+						type: TokenType.Content,
 						literal: '"00',
 						originalLength: 3,
 					},
 				},
 			],
 			literal: "\\DeclareMathSymbol",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 
 		const got = declareMathSymbol(command);
@@ -219,45 +219,45 @@ describe("declareMathSymbol", () => {
 			name: "DeclareMathSymbol",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -265,7 +265,7 @@ describe("declareMathSymbol", () => {
 				},
 			],
 			literal: "\\DeclareMathSymbol",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathSymbol(command);
 		expect(got).toBeNull();
@@ -276,34 +276,34 @@ describe("declareMathSymbol", () => {
 			name: "DeclareMathSymbol",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -311,7 +311,7 @@ describe("declareMathSymbol", () => {
 				},
 			],
 			literal: "\\DeclareMathSymbol",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathSymbol(command);
 		expect(got).toBeNull();
@@ -322,40 +322,40 @@ describe("declareMathSymbol", () => {
 			name: "DeclareMathSymbol",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "2000",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -363,7 +363,7 @@ describe("declareMathSymbol", () => {
 				},
 			],
 			literal: "\\DeclareMathSymbol",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathSymbol(command);
 		expect(got).toBeNull();
@@ -374,40 +374,40 @@ describe("declareMathSymbol", () => {
 			name: "DeclareMathSymbol",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "invalid",
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -415,7 +415,7 @@ describe("declareMathSymbol", () => {
 				},
 			],
 			literal: "\\DeclareMathSymbol",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathSymbol(command);
 		expect(got).toBeNull();
@@ -426,40 +426,40 @@ describe("declareMathSymbol", () => {
 			name: "DeclareMathSymbol",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "symbolFont",
 							originalLength: 10,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -467,7 +467,7 @@ describe("declareMathSymbol", () => {
 				},
 			],
 			literal: "\\DeclareMathSymbol",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const symbolFonts = ["symbolFont"];
 		const got = declareMathSymbol(command, symbolFonts);
@@ -484,43 +484,43 @@ describe("declareMathAccent", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -536,7 +536,7 @@ describe("declareMathAccent", () => {
 		const command: CommandToken = {
 			name: "DeclareMathAccent",
 			literal: "\\DeclareMathAccent",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 		const got = declareMathAccent(command);
@@ -548,46 +548,46 @@ describe("declareMathAccent", () => {
 			name: "DeclareMathAccent",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: {
-						type: LatexTokenType.Content,
+						type: TokenType.Content,
 						literal: '"00',
 						originalLength: 3,
 					},
 				},
 			],
 			literal: "\\DeclareMathAccent",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 
 		const got = declareMathAccent(command);
@@ -599,45 +599,45 @@ describe("declareMathAccent", () => {
 			name: "DeclareMathAccent",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -645,7 +645,7 @@ describe("declareMathAccent", () => {
 				},
 			],
 			literal: "\\DeclareMathAccent",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathAccent(command);
 		expect(got).toBeNull();
@@ -656,34 +656,34 @@ describe("declareMathAccent", () => {
 			name: "DeclareMathAccent",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -691,7 +691,7 @@ describe("declareMathAccent", () => {
 				},
 			],
 			literal: "\\DeclareMathAccent",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathAccent(command);
 		expect(got).toBeNull();
@@ -702,40 +702,40 @@ describe("declareMathAccent", () => {
 			name: "DeclareMathAccent",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "2000",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -743,7 +743,7 @@ describe("declareMathAccent", () => {
 				},
 			],
 			literal: "\\DeclareMathAccent",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathAccent(command);
 		expect(got).toBeNull();
@@ -754,40 +754,40 @@ describe("declareMathAccent", () => {
 			name: "DeclareMathAccent",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "invalid",
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -795,7 +795,7 @@ describe("declareMathAccent", () => {
 				},
 			],
 			literal: "\\DeclareMathAccent",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathAccent(command);
 		expect(got).toBeNull();
@@ -806,40 +806,40 @@ describe("declareMathAccent", () => {
 			name: "DeclareMathAccent",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "symbolFont",
 							originalLength: 10,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -847,7 +847,7 @@ describe("declareMathAccent", () => {
 				},
 			],
 			literal: "\\DeclareMathAccent",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const symbolFonts = ["symbolFont"];
 		const got = declareMathAccent(command, symbolFonts);
@@ -864,63 +864,63 @@ describe("declareMathDelimiter", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.LargeSymbols,
 							originalLength: MathSymbolFont.LargeSymbols.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"01',
 							originalLength: 3,
 						},
@@ -936,7 +936,7 @@ describe("declareMathDelimiter", () => {
 		const command: CommandToken = {
 			name: "DeclareMathDelimiter",
 			literal: "\\DeclareMathDelimiter",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 		const got = declareMathDelimiter(command);
@@ -948,58 +948,58 @@ describe("declareMathDelimiter", () => {
 			name: "DeclareMathDelimiter",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: {
-						type: LatexTokenType.Content,
+						type: TokenType.Content,
 						literal: '"00',
 						originalLength: 3,
 					},
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.LargeSymbols,
 							originalLength: MathSymbolFont.LargeSymbols.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"01',
 							originalLength: 3,
 						},
@@ -1007,7 +1007,7 @@ describe("declareMathDelimiter", () => {
 				},
 			],
 			literal: "\\DeclareMathDelimiter",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 
 		const got = declareMathDelimiter(command);
@@ -1019,65 +1019,65 @@ describe("declareMathDelimiter", () => {
 			name: "DeclareMathDelimiter",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.LargeSymbols,
 							originalLength: MathSymbolFont.LargeSymbols.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"01',
 							originalLength: 3,
 						},
@@ -1085,7 +1085,7 @@ describe("declareMathDelimiter", () => {
 				},
 			],
 			literal: "\\DeclareMathDelimiter",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathDelimiter(command);
 		expect(got).toBeNull();
@@ -1096,54 +1096,54 @@ describe("declareMathDelimiter", () => {
 			name: "DeclareMathDelimiter",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -1151,7 +1151,7 @@ describe("declareMathDelimiter", () => {
 				},
 			],
 			literal: "\\DeclareMathDelimiter",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathDelimiter(command);
 		expect(got).toBeNull();
@@ -1162,60 +1162,60 @@ describe("declareMathDelimiter", () => {
 			name: "DeclareMathDelimiter",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "2000",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -1223,7 +1223,7 @@ describe("declareMathDelimiter", () => {
 				},
 			],
 			literal: "\\DeclareMathDelimiter",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathDelimiter(command);
 		expect(got).toBeNull();
@@ -1234,60 +1234,60 @@ describe("declareMathDelimiter", () => {
 			name: "DeclareMathDelimiter",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "invalid",
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "invalid",
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
@@ -1295,7 +1295,7 @@ describe("declareMathDelimiter", () => {
 				},
 			],
 			literal: "\\DeclareMathDelimiter",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathDelimiter(command);
 		expect(got).toBeNull();
@@ -1305,63 +1305,63 @@ describe("declareMathDelimiter", () => {
 		const command: CommandToken = {
 			name: "DeclareMathDelimiter",
 			literal: "\\DeclareMathDelimiter",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "0",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: MathSymbolFont.Operators.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.LargeSymbols,
 							originalLength: MathSymbolFont.LargeSymbols.length,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"01',
 							originalLength: 3,
 						},
@@ -1384,53 +1384,53 @@ describe("declareMathRadical", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"01',
 							originalLength: 7,
 						},
@@ -1446,7 +1446,7 @@ describe("declareMathRadical", () => {
 		const command: CommandToken = {
 			name: "DeclareMathRadical",
 			literal: "\\DeclareMathRadical",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 		const got = declareMathRadical(command);
@@ -1458,56 +1458,56 @@ describe("declareMathRadical", () => {
 			name: "DeclareMathRadical",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: {
-						type: LatexTokenType.Content,
+						type: TokenType.Content,
 						literal: '"01',
 						originalLength: 7,
 					},
 				},
 			],
 			literal: "\\DeclareMathRadical",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 
 		const got = declareMathRadical(command);
@@ -1519,55 +1519,55 @@ describe("declareMathRadical", () => {
 			name: "DeclareMathRadical",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"01',
 							originalLength: 7,
 						},
@@ -1575,7 +1575,7 @@ describe("declareMathRadical", () => {
 				},
 			],
 			literal: "\\DeclareMathRadical",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathRadical(command);
 		expect(got).toBeNull();
@@ -1585,53 +1585,53 @@ describe("declareMathRadical", () => {
 		const command: CommandToken = {
 			name: "DeclareMathRadical",
 			literal: "\\DeclareMathRadical",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "-",
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.Operators,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"00',
 							originalLength: 7,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: MathSymbolFont.LargeSymbols,
 							originalLength: 1,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: '"01',
 							originalLength: 7,
 						},
@@ -1653,43 +1653,43 @@ describe("declareMathSizes", () => {
 		const command: CommandToken = {
 			name: "InvalidCommand",
 			literal: "\\InvalidCommand",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "10pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "12pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "14pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "16pt",
 							originalLength: 4,
 						},
@@ -1705,7 +1705,7 @@ describe("declareMathSizes", () => {
 		const command: CommandToken = {
 			name: "DeclareMathSizes",
 			literal: "\\DeclareMathSizes",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			arguments: [],
 		};
 		const got = declareMathSizes(command);
@@ -1717,46 +1717,46 @@ describe("declareMathSizes", () => {
 			name: "DeclareMathSizes",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "10pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "12pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "14pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Optional,
+					type: CommandArgumentType.Optional,
 					content: {
-						type: LatexTokenType.Content,
+						type: TokenType.Content,
 						literal: "16pt",
 						originalLength: 4,
 					},
 				},
 			],
 			literal: "\\DeclareMathSizes",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 
 		const got = declareMathSizes(command);
@@ -1768,45 +1768,45 @@ describe("declareMathSizes", () => {
 			name: "DeclareMathSizes",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "10pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "12pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "14pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "16pt",
 							originalLength: 4,
 						},
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "18pt",
 							originalLength: 4,
 						},
@@ -1814,7 +1814,7 @@ describe("declareMathSizes", () => {
 				},
 			],
 			literal: "\\DeclareMathSizes",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathSizes(command);
 		expect(got).toBeNull();
@@ -1825,40 +1825,40 @@ describe("declareMathSizes", () => {
 			name: "DeclareMathSizes",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "10pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "12pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "14pt",
 							originalLength: 4,
 						},
 					],
 				},
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [
 						{
-							type: LatexTokenType.Content,
+							type: TokenType.Content,
 							literal: "16pt",
 							originalLength: 4,
 						},
@@ -1866,14 +1866,14 @@ describe("declareMathSizes", () => {
 				},
 			],
 			literal: "\\DeclareMathSizes",
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 		};
 		const got = declareMathSizes(command);
 		const expected: MathSize = {
-			mathTextSize: { value: 12, unit: LatexFontSizeUnit.Point },
-			currentTextSize: { value: 10, unit: LatexFontSizeUnit.Point },
-			scriptSize: { value: 14, unit: LatexFontSizeUnit.Point },
-			scriptScriptSize: { value: 16, unit: LatexFontSizeUnit.Point },
+			mathTextSize: { value: 12, unit: FontSizeUnit.Point },
+			currentTextSize: { value: 10, unit: FontSizeUnit.Point },
+			scriptSize: { value: 14, unit: FontSizeUnit.Point },
+			scriptScriptSize: { value: 16, unit: FontSizeUnit.Point },
 		};
 		expect(got).toEqual(expected);
 	});

--- a/src/ast/math/symbols.ts
+++ b/src/ast/math/symbols.ts
@@ -1,13 +1,13 @@
 import {
+	type Argument,
+	CommandArgumentType,
 	type CommandToken,
-	type LatexArgument,
-	LatexCommandArgumentType,
-	type LatexToken,
-	LatexTokenType,
 	type RequiredArgument,
+	type Token,
+	TokenType,
 } from "../../lexer/types";
 import { getRequiredContent, isSimpleMacro } from "../../lexer/utils";
-import type { LatexFontMeasurementValue } from "../fonts/types";
+import type { FontMeasurementValue } from "../fonts/types";
 import { parseFontMeasurement } from "../fonts/utils";
 import { isSymbolFont } from "./selection";
 import {
@@ -22,15 +22,15 @@ import {
 	type SymbolFontWithSlot,
 } from "./types";
 
-export function getMathSymbolType(token?: LatexToken): MathSymbolType | null {
+export function getMathSymbolType(token?: Token): MathSymbolType | null {
 	let symbol: string;
 	if (!token) {
 		return null;
 	}
 
-	if (token.type === LatexTokenType.Content) {
+	if (token.type === TokenType.Content) {
 		symbol = token.literal;
-	} else if (token.type === LatexTokenType.Command && isSimpleMacro(token)) {
+	} else if (token.type === TokenType.Command && isSimpleMacro(token)) {
 		symbol = token.name;
 	} else {
 		return null;
@@ -66,19 +66,19 @@ export function getMathSymbolType(token?: LatexToken): MathSymbolType | null {
 	}
 }
 
-function getMathSymbolName(token?: LatexToken): MathSymbolValue | null {
+function getMathSymbolName(token?: Token): MathSymbolValue | null {
 	if (!token) {
 		return null;
 	}
 
-	if (token.type === LatexTokenType.Command) {
+	if (token.type === TokenType.Command) {
 		return {
 			type: MathSymbolValueType.Command,
 			value: token.name,
 		};
 	}
 
-	if (token.type === LatexTokenType.Content) {
+	if (token.type === TokenType.Content) {
 		const name = token.literal.trim();
 		if (name.length !== 1) {
 			return null;
@@ -94,11 +94,11 @@ function getMathSymbolName(token?: LatexToken): MathSymbolValue | null {
 }
 
 function validateSymbolFontWithSlot(
-	symbolFontToken: LatexToken | undefined,
-	slotToken: LatexToken | undefined,
+	symbolFontToken: Token | undefined,
+	slotToken: Token | undefined,
 	symbolFonts: string[],
 ): SymbolFontWithSlot | null {
-	if (!symbolFontToken || symbolFontToken.type !== LatexTokenType.Content) {
+	if (!symbolFontToken || symbolFontToken.type !== TokenType.Content) {
 		return null;
 	}
 
@@ -107,7 +107,7 @@ function validateSymbolFontWithSlot(
 		return null;
 	}
 
-	if (!slotToken || slotToken.type !== LatexTokenType.Content) {
+	if (!slotToken || slotToken.type !== TokenType.Content) {
 		return null;
 	}
 
@@ -126,8 +126,7 @@ function validateMathSymbol(
 		command.arguments.length !== 4 ||
 		command.arguments.some(
 			(arg) =>
-				arg.type !== LatexCommandArgumentType.Required ||
-				arg.content.length !== 1,
+				arg.type !== CommandArgumentType.Required || arg.content.length !== 1,
 		)
 	) {
 		return null;
@@ -182,8 +181,7 @@ export function declareMathDelimiter(
 		command.arguments.length !== 6 ||
 		command.arguments.some(
 			(arg) =>
-				arg.type !== LatexCommandArgumentType.Required ||
-				arg.content.length !== 1,
+				arg.type !== CommandArgumentType.Required || arg.content.length !== 1,
 		)
 	) {
 		return null;
@@ -242,8 +240,7 @@ export function declareMathRadical(
 		command.arguments.length !== 5 ||
 		command.arguments.some(
 			(arg) =>
-				arg.type !== LatexCommandArgumentType.Required ||
-				arg.content.length !== 1,
+				arg.type !== CommandArgumentType.Required || arg.content.length !== 1,
 		)
 	) {
 		return null;
@@ -278,9 +275,7 @@ export function declareMathRadical(
 	};
 }
 
-function parseMeasurementFromArg(
-	arg?: LatexArgument,
-): LatexFontMeasurementValue | null {
+function parseMeasurementFromArg(arg?: Argument): FontMeasurementValue | null {
 	const currentSize = getRequiredContent(arg);
 	if (!currentSize) {
 		return null;
@@ -294,8 +289,7 @@ export function declareMathSizes(command: CommandToken): MathSize | null {
 		command.arguments.length !== 4 ||
 		command.arguments.some(
 			(arg) =>
-				arg.type !== LatexCommandArgumentType.Required ||
-				arg.content.length !== 1,
+				arg.type !== CommandArgumentType.Required || arg.content.length !== 1,
 		)
 	) {
 		return null;

--- a/src/ast/math/types.ts
+++ b/src/ast/math/types.ts
@@ -1,9 +1,9 @@
 import type {
-	LatexFontEncoding,
-	LatexFontFamily,
-	LatexFontMeasurementValue,
-	LatexFontSeries,
-	LatexFontShape,
+	FontEncoding,
+	FontFamily,
+	FontMeasurementValue,
+	FontSeries,
+	FontShape,
 } from "../fonts/types";
 
 export enum MathFont {
@@ -43,10 +43,10 @@ export enum MathAlphabetDeclarationType {
 }
 
 export type MathAlphabetBase = {
-	encoding: MathAlphabetDeclarationValue<LatexFontEncoding>;
-	family: MathAlphabetDeclarationValue<LatexFontFamily>;
-	series: MathAlphabetDeclarationValue<LatexFontSeries>;
-	shape: MathAlphabetDeclarationValue<LatexFontShape>;
+	encoding: MathAlphabetDeclarationValue<FontEncoding>;
+	family: MathAlphabetDeclarationValue<FontFamily>;
+	series: MathAlphabetDeclarationValue<FontSeries>;
+	shape: MathAlphabetDeclarationValue<FontShape>;
 };
 
 export type MathAlphabetDeclaration = MathAlphabetBase & {
@@ -116,8 +116,8 @@ export type MathRadical = {
 };
 
 export type MathSize = {
-	currentTextSize: LatexFontMeasurementValue;
-	mathTextSize: LatexFontMeasurementValue;
-	scriptSize: LatexFontMeasurementValue;
-	scriptScriptSize: LatexFontMeasurementValue;
+	currentTextSize: FontMeasurementValue;
+	mathTextSize: FontMeasurementValue;
+	scriptSize: FontMeasurementValue;
+	scriptScriptSize: FontMeasurementValue;
 };

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -1,20 +1,20 @@
-import type { LatexBuiltinType } from "./builtins/types";
-import type { LatexFont } from "./fonts/types";
+import type { BuiltinType } from "./builtins/types";
+import type { Font } from "./fonts/types";
 
-export type LatexItem = LatexBuiltin | LatexFontCommand;
+export type Item = Builtin | FontCommand;
 
-export type LatexBuiltin = {
-	type: LatexItemType.BuiltIn;
-	command: LatexBuiltinType;
+export type Builtin = {
+	type: ItemType.BuiltIn;
+	command: BuiltinType;
 	name: string;
 };
 
-export type LatexFontCommand = {
-	type: LatexItemType.FontCommand;
-	font: LatexFont;
+export type FontCommand = {
+	type: ItemType.FontCommand;
+	font: Font;
 };
 
-export enum LatexItemType {
+export enum ItemType {
 	BuiltIn = 1,
 	FontCommand = 2,
 }

--- a/src/lexer/cache.test.ts
+++ b/src/lexer/cache.test.ts
@@ -2,26 +2,26 @@ import { beforeEach, describe, expect, it } from "bun:test";
 
 import { NoCache, SimpleCache } from "./cache";
 import {
-	LatexAccentType,
-	type LatexToken,
-	LatexTokenType,
 	type LexerCache,
+	type Token,
+	TokenType,
+	VariableAccent,
 } from "./types";
 
 describe("NoCache", () => {
 	it("should not store any data in the cache", () => {
 		const cache: LexerCache = new NoCache();
-		cache.add(0, { type: LatexTokenType.ColumnAlign, literal: "&" });
+		cache.add(0, { type: TokenType.ColumnAlign, literal: "&" });
 
 		let got = cache.get(0);
 		expect(got).toBeNull();
 
 		cache.add(8, {
-			type: LatexTokenType.Accent,
+			type: TokenType.Accent,
 			literal: "\\^h",
-			detail: LatexAccentType.Circumflex,
+			detail: VariableAccent.Circumflex,
 			content: {
-				type: LatexTokenType.Content,
+				type: TokenType.Content,
 				originalLength: 1,
 				literal: "h",
 			},
@@ -39,21 +39,21 @@ describe("SimpleCache", () => {
 		cache = new SimpleCache();
 	});
 
-	const tokens: LatexToken[] = [
+	const tokens: Token[] = [
 		{
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\mycommand",
 			name: "mycommand",
 			arguments: [],
 		},
-		{ type: LatexTokenType.ColumnAlign, literal: "&" },
-		{ type: LatexTokenType.Content, literal: " content1 ", originalLength: 10 },
+		{ type: TokenType.ColumnAlign, literal: "&" },
+		{ type: TokenType.Content, literal: " content1 ", originalLength: 10 },
 		{
-			type: LatexTokenType.Accent,
+			type: TokenType.Accent,
 			literal: "\\^h",
-			detail: LatexAccentType.Circumflex,
+			detail: VariableAccent.Circumflex,
 			content: {
-				type: LatexTokenType.Content,
+				type: TokenType.Content,
 				originalLength: 1,
 				literal: "h",
 			},
@@ -62,8 +62,8 @@ describe("SimpleCache", () => {
 
 	describe("get and set", () => {
 		it("should store and retrieve data in the cache", () => {
-			const token: LatexToken = {
-				type: LatexTokenType.ColumnAlign,
+			const token: Token = {
+				type: TokenType.ColumnAlign,
 				literal: "&",
 			};
 			cache.add(0, token);
@@ -72,15 +72,15 @@ describe("SimpleCache", () => {
 		});
 
 		it("should overwrite the value at that position if it already exists", () => {
-			const token1: LatexToken = {
-				type: LatexTokenType.Content,
+			const token1: Token = {
+				type: TokenType.Content,
 				literal: " content1 ",
 				originalLength: 10,
 			};
 			cache.add(0, token1);
 
-			const token2: LatexToken = {
-				type: LatexTokenType.ColumnAlign,
+			const token2: Token = {
+				type: TokenType.ColumnAlign,
 				literal: "&",
 			};
 			cache.add(0, token2);

--- a/src/lexer/cache.ts
+++ b/src/lexer/cache.ts
@@ -1,4 +1,4 @@
-import type { LatexToken, LexerCache } from "./types";
+import type { LexerCache, Token } from "./types";
 
 /**
  * A simple caching behavior that stores by their position.
@@ -6,9 +6,9 @@ import type { LatexToken, LexerCache } from "./types";
  * tests to see where the breakpoint is.
  */
 export class SimpleCache implements LexerCache {
-	private cache: Map<number, LatexToken>;
+	private cache: Map<number, Token>;
 
-	constructor(cache?: Map<number, LatexToken>) {
+	constructor(cache?: Map<number, Token>) {
 		this.cache = cache ?? new Map();
 	}
 
@@ -26,14 +26,14 @@ export class SimpleCache implements LexerCache {
 		return this;
 	}
 
-	public add(position: number, token: LatexToken): LexerCache {
+	public add(position: number, token: Token): LexerCache {
 		this.cache.set(position, token);
 		return this;
 	}
 
-	public insert(position: number, tokens: LatexToken[]): LexerCache {
+	public insert(position: number, tokens: Token[]): LexerCache {
 		let offset = 0;
-		const movedEntries: [number, LatexToken][] = [];
+		const movedEntries: [number, Token][] = [];
 
 		for (const [p, t] of this.cache.entries()) {
 			if (p >= position) {
@@ -67,7 +67,7 @@ export class SimpleCache implements LexerCache {
 
 		// If we removed 2-10, we want to shift item in slot 11 to 2, which is 10 - 2 + 1
 		const offset = endPosition - startPosition + 1;
-		const itemsToShift: [number, LatexToken][] = [];
+		const itemsToShift: [number, Token][] = [];
 		for (const [p, t] of this.cache.entries()) {
 			if (p > endPosition) {
 				// Store the items to shift so we don't mutate the map while iterating through it (quirk of JavaScript).
@@ -85,7 +85,7 @@ export class SimpleCache implements LexerCache {
 		return this;
 	}
 
-	public get(position: number): LatexToken | null {
+	public get(position: number): Token | null {
 		return this.cache.get(position) ?? null;
 	}
 }
@@ -103,7 +103,7 @@ export class NoCache implements LexerCache {
 	remove(): LexerCache {
 		return this;
 	}
-	get(): LatexToken | null {
+	get(): Token | null {
 		return null;
 	}
 }

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -3,8 +3,8 @@ import { NoCache } from "./cache";
 import {
 	type AccentToken,
 	type Arguments,
+	type BlockRequiredAccent,
 	type BlockToken,
-	type BraceRequiredAccent,
 	CharType,
 	CommandArgumentType,
 	type CommandToken,
@@ -55,7 +55,7 @@ export class Lexer {
 		".",
 	]);
 
-	static readonly BRACES_REQUIRED_ACCENT_CHARACTERS = new Set([
+	static readonly BLOCK_REQUIRED_ACCENT_CHARACTERS = new Set([
 		"H",
 		"c",
 		"b",
@@ -362,12 +362,12 @@ export class Lexer {
 	private isBracesRequiredAccent(
 		nextChar: string,
 		charAfter: string | undefined,
-	): nextChar is BraceRequiredAccent {
+	): nextChar is BlockRequiredAccent {
 		if (charAfter !== CharType.OpenBrace) {
 			return false;
 		}
 
-		return Lexer.BRACES_REQUIRED_ACCENT_CHARACTERS.has(nextChar);
+		return Lexer.BLOCK_REQUIRED_ACCENT_CHARACTERS.has(nextChar);
 	}
 
 	private isVariableAccent(nextChar: string): nextChar is VariableAccent {
@@ -376,7 +376,7 @@ export class Lexer {
 
 	private buildBracketRequiredAccent(
 		startPosition: number,
-		accentChar: BraceRequiredAccent,
+		accentChar: BlockRequiredAccent,
 	): AccentToken {
 		const token = this.buildBlock(startPosition + 1);
 		return {

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -2,17 +2,15 @@ import { clamp } from "../utils";
 import { NoCache } from "./cache";
 import {
 	type AccentToken,
+	type Arguments,
 	type BlockToken,
 	type BraceRequiredAccent,
+	CharType,
+	CommandArgumentType,
 	type CommandToken,
 	type CommentToken,
 	type ContentToken,
 	type LabeledArgContent,
-	type LatexArguments,
-	LatexCharType,
-	LatexCommandArgumentType,
-	type LatexToken,
-	LatexTokenType,
 	type LexerCache,
 	MathPosition,
 	type MathToken,
@@ -21,6 +19,8 @@ import {
 	type RequiredArgument,
 	type ScriptToken,
 	ScriptTokenType,
+	type Token,
+	TokenType,
 	type VariableAccent,
 } from "./types";
 /**
@@ -30,7 +30,7 @@ import {
  *
  * If no cache is provided, it defaults to no caching.
  */
-export class LatexLexer {
+export class Lexer {
 	static readonly REPLACE_ESCAPE_CHARACTER_MAP = {
 		// \ followed by a newline means continue as if the line didn't break
 		"\\#": "@@<!HASH!>",
@@ -77,7 +77,7 @@ export class LatexLexer {
 	private escapeInput(input: string): string {
 		let escapedInput = input;
 		for (const [escapedSequence, escapeSequence] of Object.entries(
-			LatexLexer.REPLACE_ESCAPE_CHARACTER_MAP,
+			Lexer.REPLACE_ESCAPE_CHARACTER_MAP,
 		)) {
 			escapedInput = escapedInput.replaceAll(escapedSequence, escapeSequence);
 		}
@@ -89,7 +89,7 @@ export class LatexLexer {
 	private unescapeContent(input: string): string {
 		let unescapedInput = input;
 		for (const [escapedSequence, escapeSequence] of Object.entries(
-			LatexLexer.REPLACE_ESCAPE_CHARACTER_MAP,
+			Lexer.REPLACE_ESCAPE_CHARACTER_MAP,
 		)) {
 			unescapedInput = unescapedInput.replaceAll(
 				escapeSequence,
@@ -103,7 +103,7 @@ export class LatexLexer {
 	private deescapeContent(input: string): string {
 		let deescapedInput = input;
 		for (const [escapedSequence, escapeSequence] of Object.entries(
-			LatexLexer.REPLACE_ESCAPE_CHARACTER_MAP,
+			Lexer.REPLACE_ESCAPE_CHARACTER_MAP,
 		)) {
 			deescapedInput = deescapedInput.replaceAll(
 				escapeSequence,
@@ -123,7 +123,7 @@ export class LatexLexer {
 		this.position = clamp(pos, 0, this.input.length);
 	}
 
-	public insert(position: number, value: string): LatexLexer {
+	public insert(position: number, value: string): Lexer {
 		let pos = position;
 		if (pos < 0) {
 			pos = this.input.length + pos;
@@ -143,7 +143,7 @@ export class LatexLexer {
 		return this;
 	}
 
-	public remove(start: number, end: number): LatexLexer {
+	public remove(start: number, end: number): Lexer {
 		let removeStart = start;
 		let removeEnd = end;
 
@@ -186,20 +186,20 @@ export class LatexLexer {
 	private buildContent(startPosition: number): ContentToken {
 		const content = this.readUntil(startPosition, (c) => {
 			return (
-				c === LatexCharType.Backslash ||
-				c === LatexCharType.OpenBrace ||
-				c === LatexCharType.CloseBrace ||
-				c === LatexCharType.Percent ||
-				c === LatexCharType.Dollar ||
-				c === LatexCharType.Ampersand ||
-				c === LatexCharType.Hash ||
-				c === LatexCharType.Underscore ||
-				c === LatexCharType.Caret
+				c === CharType.Backslash ||
+				c === CharType.OpenBrace ||
+				c === CharType.CloseBrace ||
+				c === CharType.Percent ||
+				c === CharType.Dollar ||
+				c === CharType.Ampersand ||
+				c === CharType.Hash ||
+				c === CharType.Underscore ||
+				c === CharType.Caret
 			);
 		});
 
 		return {
-			type: LatexTokenType.Content,
+			type: TokenType.Content,
 			literal: this.unescapeContent(content),
 			originalLength: content.length,
 		};
@@ -207,12 +207,12 @@ export class LatexLexer {
 
 	private buildParagraphMath(
 		startPosition: number,
-		startMathCharacter: LatexCharType.OpenBracket | LatexCharType.OpenParen,
+		startMathCharacter: CharType.OpenBracket | CharType.OpenParen,
 	): MathToken {
 		const endMathCharacter =
-			startMathCharacter === LatexCharType.OpenBracket
-				? LatexCharType.CloseBracket
-				: LatexCharType.CloseParen;
+			startMathCharacter === CharType.OpenBracket
+				? CharType.CloseBracket
+				: CharType.CloseParen;
 
 		const endIndex = this.input.indexOf(`\\${endMathCharacter}`);
 		if (endIndex === -1) {
@@ -221,14 +221,14 @@ export class LatexLexer {
 
 		const content = this.input.slice(startPosition, endIndex);
 		const mathPosition =
-			endMathCharacter === LatexCharType.CloseBracket
+			endMathCharacter === CharType.CloseBracket
 				? MathPosition.Centered
 				: MathPosition.Block;
 
-		const lexer = new LatexLexer(content);
+		const lexer = new Lexer(content);
 
 		return {
-			type: LatexTokenType.Math,
+			type: TokenType.Math,
 			literal: `\\${startMathCharacter}${content}\\${endMathCharacter}`,
 			content: lexer.readToEnd(),
 			position: mathPosition,
@@ -241,7 +241,7 @@ export class LatexLexer {
 	): AccentToken {
 		const token = this.buildModifiableToken(startPosition);
 		return {
-			type: LatexTokenType.Accent,
+			type: TokenType.Accent,
 			literal: `\\${accentChar}${token.literal}`,
 			detail: accentChar,
 			content: token,
@@ -250,12 +250,12 @@ export class LatexLexer {
 
 	private getSectionWithPossibleNesting(
 		startPosition: number,
-		endCharacter: LatexCharType,
+		endCharacter: CharType,
 		mustClose = false,
 	): string {
 		let position = startPosition;
 		let char = this.readChar(position);
-		const stack: LatexCommandArgumentType[] = [];
+		const stack: CommandArgumentType[] = [];
 
 		let arg = "";
 		while (true) {
@@ -276,18 +276,18 @@ export class LatexLexer {
 			arg += char;
 			position++;
 
-			if (char === LatexCharType.OpenBrace) {
-				stack.push(LatexCommandArgumentType.Required);
-			} else if (char === LatexCharType.OpenBracket) {
-				stack.push(LatexCommandArgumentType.Optional);
-			} else if (char === LatexCharType.CloseBrace) {
-				if (stack[stack.length - 1] !== LatexCommandArgumentType.Required) {
+			if (char === CharType.OpenBrace) {
+				stack.push(CommandArgumentType.Required);
+			} else if (char === CharType.OpenBracket) {
+				stack.push(CommandArgumentType.Optional);
+			} else if (char === CharType.CloseBrace) {
+				if (stack[stack.length - 1] !== CommandArgumentType.Required) {
 					throw new Error("Mismatched braces");
 				}
 
 				stack.pop();
-			} else if (char === LatexCharType.CloseBracket) {
-				if (stack[stack.length - 1] !== LatexCommandArgumentType.Optional) {
+			} else if (char === CharType.CloseBracket) {
+				if (stack[stack.length - 1] !== CommandArgumentType.Optional) {
 					throw new Error("Mismatched braces");
 				}
 
@@ -308,39 +308,39 @@ export class LatexLexer {
 			throw new Error("Command never closed");
 		}
 
-		const args: LatexArguments = [];
+		const args: Arguments = [];
 		let position = startPosition + name.length;
 
 		while (true) {
 			const char = this.readChar(position);
 
-			if (char === LatexCharType.OpenBrace) {
+			if (char === CharType.OpenBrace) {
 				// getSectionWithPossibleNesting won't include the opening or closing braces
 				const content = this.getSectionWithPossibleNesting(
 					position + 1,
-					LatexCharType.CloseBrace,
+					CharType.CloseBrace,
 				);
 				const requiredArg = this.buildRequiredArg(content);
 
 				args.push(requiredArg);
 				position += content.length + 2;
-				if (this.readChar(position - 1) !== LatexCharType.CloseBrace) {
+				if (this.readChar(position - 1) !== CharType.CloseBrace) {
 					throw new Error("Required argument never closed");
 				}
 				continue;
 			}
 
-			if (char === LatexCharType.OpenBracket) {
+			if (char === CharType.OpenBracket) {
 				const content = this.getSectionWithPossibleNesting(
 					position + 1,
-					LatexCharType.CloseBracket,
+					CharType.CloseBracket,
 				);
 				const optionalArg = this.buildOptionalArg(content);
 
 				args.push(optionalArg);
 				position += content.length + 2;
 
-				if (this.readChar(position - 1) !== LatexCharType.CloseBracket) {
+				if (this.readChar(position - 1) !== CharType.CloseBracket) {
 					throw new Error("Optional argument never closed");
 				}
 				continue;
@@ -352,7 +352,7 @@ export class LatexLexer {
 		const literal = this.input.slice(startPosition, position);
 
 		return {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: `\\${literal}`,
 			arguments: args,
 			name,
@@ -363,15 +363,15 @@ export class LatexLexer {
 		nextChar: string,
 		charAfter: string | undefined,
 	): nextChar is BraceRequiredAccent {
-		if (charAfter !== LatexCharType.OpenBrace) {
+		if (charAfter !== CharType.OpenBrace) {
 			return false;
 		}
 
-		return LatexLexer.BRACES_REQUIRED_ACCENT_CHARACTERS.has(nextChar);
+		return Lexer.BRACES_REQUIRED_ACCENT_CHARACTERS.has(nextChar);
 	}
 
 	private isVariableAccent(nextChar: string): nextChar is VariableAccent {
-		return LatexLexer.VARIABLE_ACCENT_CHARACTERS.has(nextChar);
+		return Lexer.VARIABLE_ACCENT_CHARACTERS.has(nextChar);
 	}
 
 	private buildBracketRequiredAccent(
@@ -380,7 +380,7 @@ export class LatexLexer {
 	): AccentToken {
 		const token = this.buildBlock(startPosition + 1);
 		return {
-			type: LatexTokenType.Accent,
+			type: TokenType.Accent,
 			literal: `\\${accentChar}${token.literal}`,
 			detail: accentChar,
 			content: token,
@@ -395,10 +395,7 @@ export class LatexLexer {
 			throw new Error("Command never closed");
 		}
 
-		if (
-			nextChar === LatexCharType.OpenBracket ||
-			nextChar === LatexCharType.OpenParen
-		) {
+		if (nextChar === CharType.OpenBracket || nextChar === CharType.OpenParen) {
 			return this.buildParagraphMath(startPosition + 1, nextChar);
 		}
 
@@ -420,7 +417,7 @@ export class LatexLexer {
 	}
 
 	private assertOptionalArgTokenOption(
-		lexer: LatexLexer,
+		lexer: Lexer,
 	): CommandToken | ContentToken {
 		const tokens = lexer.readToEnd();
 		if (tokens.length !== 1) {
@@ -429,10 +426,7 @@ export class LatexLexer {
 
 		const [token] = tokens;
 
-		if (
-			token.type === LatexTokenType.Command ||
-			token.type === LatexTokenType.Content
-		) {
+		if (token.type === TokenType.Command || token.type === TokenType.Content) {
 			return token;
 		}
 
@@ -442,10 +436,10 @@ export class LatexLexer {
 	}
 
 	private buildRequiredArg(content: string): RequiredArgument {
-		const lexer = new LatexLexer(content);
+		const lexer = new Lexer(content);
 
 		return {
-			type: LatexCommandArgumentType.Required,
+			type: CommandArgumentType.Required,
 			content: lexer.readToEnd(),
 		};
 	}
@@ -463,24 +457,22 @@ export class LatexLexer {
 
 		const [k, v] = kv;
 
-		const lexer = new LatexLexer(v);
+		const lexer = new Lexer(v);
 		const arg = this.assertOptionalArgTokenOption(lexer);
 		return { key: k.trimStart(), value: [arg] };
 	}
 
-	private getOptionalArguments(
-		tokens: LatexToken[],
-	): OptionalArgument["content"] {
+	private getOptionalArguments(tokens: Token[]): OptionalArgument["content"] {
 		// TODO: Refactor this - it's a mess right now
 		if (tokens.length === 1) {
 			const [token] = tokens;
 
-			// A singular command - we have one LatexToken
-			if (token.type === LatexTokenType.Command) {
+			// A singular command - we have one Token
+			if (token.type === TokenType.Command) {
 				return token;
 			}
 
-			if (token.type === LatexTokenType.Content) {
+			if (token.type === TokenType.Content) {
 				// We have all labeled arguments without commands
 				if (token.literal.includes("=")) {
 					const labeledArgs: LabeledArgContent[] = [];
@@ -508,13 +500,13 @@ export class LatexLexer {
 		// \\command3[a=b,b=\\arg1{%\nCool Th_in^g: #1}[a=^7,b=c,d=e],c=d]
 		const labeledArgs: LabeledArgContent[] = [];
 		let key = "";
-		let value: LatexToken[] = [];
+		let value: Token[] = [];
 		for (const token of tokens) {
 			// If we get a content section that starts with a comma
 			// then we have
 			if (
-				token.type === LatexTokenType.Content &&
-				token.literal.startsWith(LatexCharType.Comma)
+				token.type === TokenType.Content &&
+				token.literal.startsWith(CharType.Comma)
 			) {
 				const arg: LabeledArgContent = { key, value };
 				labeledArgs.push(arg);
@@ -542,13 +534,13 @@ export class LatexLexer {
 			}
 
 			if (
-				token.type === LatexTokenType.Content &&
-				token.literal.includes(LatexCharType.Comma) &&
+				token.type === TokenType.Content &&
+				token.literal.includes(CharType.Comma) &&
 				key !== ""
 			) {
 				const [v] = token.literal.split(",");
 				const vToken: ContentToken = {
-					type: LatexTokenType.Content,
+					type: TokenType.Content,
 					literal: v,
 					originalLength: v.length,
 				};
@@ -565,7 +557,7 @@ export class LatexLexer {
 			}
 
 			if (key === "") {
-				if (token.type !== LatexTokenType.Content) {
+				if (token.type !== TokenType.Content) {
 					throw new Error(
 						`Expected to receive an alphanumeric key name, instead got ${token}`,
 					);
@@ -604,11 +596,11 @@ export class LatexLexer {
 	}
 
 	private buildOptionalArg(content: string): OptionalArgument {
-		const tokens = new LatexLexer(content).readToEnd();
+		const tokens = new Lexer(content).readToEnd();
 		const args = this.getOptionalArguments(tokens);
 
 		return {
-			type: LatexCommandArgumentType.Optional,
+			type: CommandArgumentType.Optional,
 			content: args,
 		};
 	}
@@ -616,12 +608,12 @@ export class LatexLexer {
 	private buildBlock(startPosition: number): BlockToken {
 		const content = this.getSectionWithPossibleNesting(
 			startPosition,
-			LatexCharType.CloseBrace,
+			CharType.CloseBrace,
 			true,
 		);
-		const lexer = new LatexLexer(content);
+		const lexer = new Lexer(content);
 		return {
-			type: LatexTokenType.Block,
+			type: TokenType.Block,
 			literal: `{${content}}`,
 			content: lexer.readToEnd(),
 		};
@@ -630,14 +622,14 @@ export class LatexLexer {
 	private buildComment(startPosition: number): CommentToken {
 		const content = this.readUntil(
 			startPosition,
-			(c) => c === LatexCharType.Newline,
+			(c) => c === CharType.Newline,
 		);
 		let literal = content;
 		if (this.readChar(startPosition + content.length)) {
 			literal += "\n";
 		}
 		return {
-			type: LatexTokenType.Comment,
+			type: TokenType.Comment,
 			literal: `%${literal}`,
 			content: this.deescapeContent(content),
 		};
@@ -654,7 +646,7 @@ export class LatexLexer {
 		}
 
 		return {
-			type: LatexTokenType.Placeholder,
+			type: TokenType.Placeholder,
 			literal: `#${parsedContent}`,
 			content: parsedContent,
 		};
@@ -665,9 +657,9 @@ export class LatexLexer {
 		if (this.readChar(startPosition + content.length) !== "$") {
 			throw new Error("Inline math block not closed");
 		}
-		const lexer = new LatexLexer(content);
+		const lexer = new Lexer(content);
 		return {
-			type: LatexTokenType.Math,
+			type: TokenType.Math,
 			literal: `$${content}$`,
 			content: lexer.readToEnd(),
 			position: MathPosition.Inline,
@@ -688,19 +680,19 @@ export class LatexLexer {
 
 		if (/\w/.test(char)) {
 			return {
-				type: LatexTokenType.Content,
+				type: TokenType.Content,
 				literal: char,
 				originalLength: 1,
 			};
 		}
 
-		if (char === LatexCharType.OpenBrace) {
+		if (char === CharType.OpenBrace) {
 			return this.buildBlock(startPosition + 1);
 		}
 
-		if (char === LatexCharType.Backslash) {
+		if (char === CharType.Backslash) {
 			const command = this.buildCommand(startPosition + 1);
-			if (command.type !== LatexTokenType.Command) {
+			if (command.type !== TokenType.Command) {
 				throw err;
 			}
 			return command;
@@ -711,21 +703,19 @@ export class LatexLexer {
 
 	private buildScript(
 		startPosition: number,
-		char: LatexCharType.Caret | LatexCharType.Underscore,
+		char: CharType.Caret | CharType.Underscore,
 	): ScriptToken {
 		const token = this.buildModifiableToken(startPosition);
 		return {
-			type: LatexTokenType.Script,
+			type: TokenType.Script,
 			detail:
-				char === LatexCharType.Caret
-					? ScriptTokenType.Super
-					: ScriptTokenType.Sub,
+				char === CharType.Caret ? ScriptTokenType.Super : ScriptTokenType.Sub,
 			literal: `${char}${token.literal}`,
 			content: token,
 		};
 	}
 
-	public peek(advance = 0): LatexToken | null {
+	public peek(advance = 0): Token | null {
 		const position = this.position + advance;
 		const char = this.input.at(position);
 		if (!char) {
@@ -737,36 +727,36 @@ export class LatexLexer {
 			return cachedItem;
 		}
 
-		let token: LatexToken;
+		let token: Token;
 		switch (char) {
-			case LatexCharType.CloseBrace:
-			case LatexCharType.CloseBracket:
+			case CharType.CloseBrace:
+			case CharType.CloseBracket:
 				throw new Error(`Could not detect opening character matching ${char}`);
-			case LatexCharType.OpenBrace:
+			case CharType.OpenBrace:
 				token = this.buildBlock(position + 1);
 				break;
-			case LatexCharType.Backslash:
+			case CharType.Backslash:
 				token = this.buildCommand(position + 1);
 				break;
-			case LatexCharType.Caret:
+			case CharType.Caret:
 				token = this.buildScript(position + 1, char);
 				break;
-			case LatexCharType.Underscore:
+			case CharType.Underscore:
 				token = this.buildScript(position + 1, char);
 				break;
-			case LatexCharType.Ampersand:
+			case CharType.Ampersand:
 				token = {
-					type: LatexTokenType.ColumnAlign,
+					type: TokenType.ColumnAlign,
 					literal: char,
 				};
 				break;
-			case LatexCharType.Percent:
+			case CharType.Percent:
 				token = this.buildComment(position + 1);
 				break;
-			case LatexCharType.Hash:
+			case CharType.Hash:
 				token = this.buildPlaceholder(position + 1);
 				break;
-			case LatexCharType.Dollar:
+			case CharType.Dollar:
 				token = this.buildInlineMath(position + 1);
 				break;
 			default:
@@ -778,13 +768,13 @@ export class LatexLexer {
 		return token;
 	}
 
-	public nextToken(): LatexToken | null {
+	public nextToken(): Token | null {
 		const token = this.peek();
 		if (!token) {
 			return null;
 		}
 
-		if (token.type === LatexTokenType.Content) {
+		if (token.type === TokenType.Content) {
 			this.position += token.originalLength;
 		} else {
 			this.position += token.literal.length;
@@ -793,7 +783,7 @@ export class LatexLexer {
 		return token;
 	}
 
-	public next(): IteratorResult<LatexToken> {
+	public next(): IteratorResult<Token> {
 		const token = this.nextToken();
 		if (!token) {
 			return { done: true, value: token };
@@ -809,7 +799,7 @@ export class LatexLexer {
 	/**
 	 * Reads through the whole iterator from the beginning.
 	 */
-	public readToEnd(): LatexToken[] {
+	public readToEnd(): Token[] {
 		this.seek(0);
 		return [...this];
 	}

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -152,7 +152,7 @@ export enum CharType {
  * or a group of characters enclosed in braces. For accents that are alphabetic characters, the accent must
  * be followed by a group of characters (or a single character) enclosed in braces.
  */
-export type AccentType = VariableAccent | BraceRequiredAccent;
+export type AccentType = VariableAccent | BlockRequiredAccent;
 export enum VariableAccent {
 	Circumflex = "^",
 	Tilde = "~",
@@ -163,7 +163,7 @@ export enum VariableAccent {
 	OverDot = ".",
 }
 
-export enum BraceRequiredAccent {
+export enum BlockRequiredAccent {
 	HungarianUmlaut = "H",
 	Cedilla = "c",
 	UnderBar = "b",

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -12,8 +12,8 @@ export type LatexToken =
 
 export type AccentToken = {
 	type: LatexTokenType.Accent;
-	literal: `\\${"^" | "~"}${string}`;
-	detail: LatexAccentType;
+	literal: `\\${AccentType}${string}`;
+	detail: AccentType;
 	content: LatexToken;
 };
 
@@ -146,9 +146,31 @@ export enum LatexCharType {
 	Comma = ",",
 }
 
-export enum LatexAccentType {
+/**
+ * Accents contain a backslash then an accent character, as shown in the LatexAccentType enum.
+ * For accents that are a non-alphabetic character, the account can either be followed by a single character
+ * or a group of characters enclosed in braces. For accents that are alphabetic characters, the accent must
+ * be followed by a group of characters (or a single character) enclosed in braces.
+ */
+export type AccentType = VariableAccent | BraceRequiredAccent;
+export enum VariableAccent {
 	Circumflex = "\\^",
 	Tilde = "\\~",
+	Grave = "\\`",
+	Acute = "\\'",
+	Diaresis = '\\"',
+	Macron = "\\=",
+	OverDot = "\\.",
+}
+
+export enum BraceRequiredAccent {
+	HungarianUmlaut = "\\H",
+	Cedilla = "\\c",
+	UnderBar = "\\b",
+	UnderDot = "\\d",
+	Breve = "\\u",
+	OverVector = "\\v",
+	Tie = "\\t",
 }
 
 export interface LexerCache {

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -1,4 +1,4 @@
-export type LatexToken =
+export type Token =
 	| CommandToken
 	| MathToken
 	| BlockToken
@@ -11,37 +11,37 @@ export type LatexToken =
 	| EndOfLineToken;
 
 export type AccentToken = {
-	type: LatexTokenType.Accent;
+	type: TokenType.Accent;
 	literal: `\\${AccentType}${string}`;
 	detail: AccentType;
-	content: LatexToken;
+	content: Token;
 };
 
 export type RequiredArgument = {
-	type: LatexCommandArgumentType.Required;
-	content: LatexToken[];
+	type: CommandArgumentType.Required;
+	content: Token[];
 };
 
 export type OptionalArgument = {
-	type: LatexCommandArgumentType.Optional;
+	type: CommandArgumentType.Optional;
 	content: CommandToken | ContentToken | LabeledArgContent[];
 };
 
-export type LatexArgument = RequiredArgument | OptionalArgument;
-export type LatexArguments = LatexArgument[];
+export type Argument = RequiredArgument | OptionalArgument;
+export type Arguments = Argument[];
 
 export type SimpleMacro = {
-	type: LatexTokenType.Command;
+	type: TokenType.Command;
 	literal: `\\${string}`;
 	name: string;
 	arguments: [];
 };
 
 export type CommandToken = {
-	type: LatexTokenType.Command;
+	type: TokenType.Command;
 	literal: `\\${string}`;
 	name: string;
-	arguments: LatexArguments;
+	arguments: Arguments;
 };
 
 export enum MathPosition {
@@ -53,33 +53,33 @@ export enum MathPosition {
 type MathStartCharacter = "$" | "\\(" | "\\[";
 type MathEndCharacter = "$" | "\\)" | "\\]";
 export type MathToken = {
-	type: LatexTokenType.Math;
+	type: TokenType.Math;
 	literal: `${MathStartCharacter}${string}${MathEndCharacter}`;
-	content: LatexToken[];
+	content: Token[];
 	position: MathPosition;
 };
 
 export type BlockToken = {
-	type: LatexTokenType.Block;
+	type: TokenType.Block;
 	literal: `{${string}}`;
-	content: LatexToken[];
+	content: Token[];
 };
 
-export type LabeledArgContent = { key: string; value: LatexToken[] };
+export type LabeledArgContent = { key: string; value: Token[] };
 
 export type CommentToken = {
-	type: LatexTokenType.Comment;
+	type: TokenType.Comment;
 	literal: `%${string}`;
 	content: string;
 };
 
 export type ColumnAlignToken = {
-	type: LatexTokenType.ColumnAlign;
+	type: TokenType.ColumnAlign;
 	literal: "&";
 };
 
 export type PlaceholderToken = {
-	type: LatexTokenType.Placeholder;
+	type: TokenType.Placeholder;
 	literal: `#${string}`;
 	content: number;
 };
@@ -89,30 +89,30 @@ export enum ScriptTokenType {
 	Sub = "_",
 }
 export type ScriptToken = {
-	type: LatexTokenType.Script;
+	type: TokenType.Script;
 	detail: ScriptTokenType;
 	literal: `${ScriptTokenType}${string}`;
-	content: LatexToken;
+	content: Token;
 };
 
 export type EndOfLineToken = {
-	type: LatexTokenType.EndOfLine;
+	type: TokenType.EndOfLine;
 	literal: "\n";
 	continueText: boolean;
 };
 
 export type ContentToken = {
-	type: LatexTokenType.Content;
+	type: TokenType.Content;
 	literal: string;
 	originalLength: number;
 };
 
-export enum LatexCommandArgumentType {
+export enum CommandArgumentType {
 	Optional = 1,
 	Required = 2,
 }
 
-export enum LatexTokenType {
+export enum TokenType {
 	Command = "command",
 	Math = "math",
 	Block = "block",
@@ -126,7 +126,7 @@ export enum LatexTokenType {
 	Accent = "accent",
 }
 
-export enum LatexCharType {
+export enum CharType {
 	Backslash = "\\",
 	OpenBracket = "[",
 	CloseBracket = "]",
@@ -147,36 +147,36 @@ export enum LatexCharType {
 }
 
 /**
- * Accents contain a backslash then an accent character, as shown in the LatexAccentType enum.
+ * Accents contain a backslash then an accent character, as shown in the AccentType enum.
  * For accents that are a non-alphabetic character, the account can either be followed by a single character
  * or a group of characters enclosed in braces. For accents that are alphabetic characters, the accent must
  * be followed by a group of characters (or a single character) enclosed in braces.
  */
 export type AccentType = VariableAccent | BraceRequiredAccent;
 export enum VariableAccent {
-	Circumflex = "\\^",
-	Tilde = "\\~",
-	Grave = "\\`",
-	Acute = "\\'",
-	Diaresis = '\\"',
-	Macron = "\\=",
-	OverDot = "\\.",
+	Circumflex = "^",
+	Tilde = "~",
+	Grave = "`",
+	Acute = "'",
+	Diaresis = '"',
+	Macron = "=",
+	OverDot = ".",
 }
 
 export enum BraceRequiredAccent {
-	HungarianUmlaut = "\\H",
-	Cedilla = "\\c",
-	UnderBar = "\\b",
-	UnderDot = "\\d",
-	Breve = "\\u",
-	OverVector = "\\v",
-	Tie = "\\t",
+	HungarianUmlaut = "H",
+	Cedilla = "c",
+	UnderBar = "b",
+	UnderDot = "d",
+	Breve = "u",
+	OverVector = "v",
+	Tie = "t",
 }
 
 export interface LexerCache {
-	add(position: number, token: LatexToken): LexerCache;
-	insert(position: number, token: LatexToken[]): LexerCache;
+	add(position: number, token: Token): LexerCache;
+	insert(position: number, token: Token[]): LexerCache;
 	remove(start: number, end: number): LexerCache;
-	get(position: number): LatexToken | null;
+	get(position: number): Token | null;
 	evict(start: number, end: number): LexerCache;
 }

--- a/src/lexer/utils.test.ts
+++ b/src/lexer/utils.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+	type Argument,
+	CommandArgumentType,
 	type CommandToken,
 	type ContentToken,
-	type LatexArgument,
-	LatexCommandArgumentType,
-	type LatexToken,
-	LatexTokenType,
 	type PlaceholderToken,
 	type SimpleMacro,
+	type Token,
+	TokenType,
 } from "./types";
 import {
 	getRequiredContent,
@@ -20,7 +20,7 @@ import {
 describe("isSimpleMacro", () => {
 	it("should return true if the token is a command with no arguments", () => {
 		const token: SimpleMacro = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\macro",
 			name: "macro",
 			arguments: [],
@@ -30,7 +30,7 @@ describe("isSimpleMacro", () => {
 
 	it("should return false if the token is not a command", () => {
 		const token: PlaceholderToken = {
-			type: LatexTokenType.Placeholder,
+			type: TokenType.Placeholder,
 			literal: "#1",
 			content: 1,
 		};
@@ -39,12 +39,12 @@ describe("isSimpleMacro", () => {
 
 	it("should return false if the token has arguments", () => {
 		const token: CommandToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\macro",
 			name: "macro",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 			],
@@ -60,8 +60,8 @@ describe("getRequiredContentItem", () => {
 	});
 
 	it("should return null if the argument type is not Required", () => {
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Optional,
+		const arg: Argument = {
+			type: CommandArgumentType.Optional,
 			content: [],
 		};
 		const got = getRequiredContentItem(arg);
@@ -69,11 +69,11 @@ describe("getRequiredContentItem", () => {
 	});
 
 	it("should return null if the argument content length is not 1", () => {
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Required,
+		const arg: Argument = {
+			type: CommandArgumentType.Required,
 			content: [
-				{ type: LatexTokenType.Content, literal: "item1", originalLength: 5 },
-				{ type: LatexTokenType.Content, literal: "item2", originalLength: 5 },
+				{ type: TokenType.Content, literal: "item1", originalLength: 5 },
+				{ type: TokenType.Content, literal: "item2", originalLength: 5 },
 			],
 		};
 		const got = getRequiredContentItem(arg);
@@ -82,12 +82,12 @@ describe("getRequiredContentItem", () => {
 
 	it("should return the content item if the argument is valid", () => {
 		const contentToken: ContentToken = {
-			type: LatexTokenType.Content,
+			type: TokenType.Content,
 			literal: "item1",
 			originalLength: 5,
 		};
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Required,
+		const arg: Argument = {
+			type: CommandArgumentType.Required,
 			content: [contentToken],
 		};
 		const got = getRequiredContentItem(arg);
@@ -102,8 +102,8 @@ describe("getRequiredSimpleMacro", () => {
 	});
 
 	it("should return null if the argument is not a required content item", () => {
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Optional,
+		const arg: Argument = {
+			type: CommandArgumentType.Optional,
 			content: [],
 		};
 		const got = getRequiredSimpleMacro(arg);
@@ -111,25 +111,25 @@ describe("getRequiredSimpleMacro", () => {
 	});
 
 	it("should return null if the argument content is not a simple macro", () => {
-		let contentToken: LatexToken = {
-			type: LatexTokenType.Content,
+		let contentToken: Token = {
+			type: TokenType.Content,
 			literal: "item1",
 			originalLength: 5,
 		};
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Required,
+		const arg: Argument = {
+			type: CommandArgumentType.Required,
 			content: [contentToken],
 		};
 		let got = getRequiredSimpleMacro(arg);
 		expect(got).toBeNull();
 
 		contentToken = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\macro",
 			name: "macro",
 			arguments: [
 				{
-					type: LatexCommandArgumentType.Required,
+					type: CommandArgumentType.Required,
 					content: [],
 				},
 			],
@@ -140,13 +140,13 @@ describe("getRequiredSimpleMacro", () => {
 
 	it("should return the simple macro if the argument is valid", () => {
 		const token: SimpleMacro = {
-			type: LatexTokenType.Command,
+			type: TokenType.Command,
 			literal: "\\macro",
 			name: "macro",
 			arguments: [],
 		};
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Required,
+		const arg: Argument = {
+			type: CommandArgumentType.Required,
 			content: [token],
 		};
 		const got = getRequiredSimpleMacro(arg);
@@ -160,8 +160,8 @@ describe("getRequiredContent", () => {
 	});
 
 	it("should return null if the argument type is not Required", () => {
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Optional,
+		const arg: Argument = {
+			type: CommandArgumentType.Optional,
 			content: [],
 		};
 		const got = getRequiredContent(arg);
@@ -169,11 +169,11 @@ describe("getRequiredContent", () => {
 	});
 
 	it("should return null if the argument content is not a content token", () => {
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Required,
+		const arg: Argument = {
+			type: CommandArgumentType.Required,
 			content: [
 				{
-					type: LatexTokenType.Command,
+					type: TokenType.Command,
 					literal: "\\macro",
 					name: "macro",
 					arguments: [],
@@ -185,13 +185,13 @@ describe("getRequiredContent", () => {
 	});
 
 	it("should return the content literal if the argument is valid", () => {
-		const contentToken: LatexToken = {
-			type: LatexTokenType.Content,
+		const contentToken: Token = {
+			type: TokenType.Content,
 			literal: "item1",
 			originalLength: 5,
 		};
-		const arg: LatexArgument = {
-			type: LatexCommandArgumentType.Required,
+		const arg: Argument = {
+			type: CommandArgumentType.Required,
 			content: [contentToken],
 		};
 		const got = getRequiredContent(arg);

--- a/src/lexer/utils.ts
+++ b/src/lexer/utils.ts
@@ -1,26 +1,26 @@
 import {
+	type Argument,
+	CommandArgumentType,
 	type CommandToken,
-	type LatexArgument,
-	LatexCommandArgumentType,
-	type LatexToken,
-	LatexTokenType,
 	type SimpleMacro,
+	type Token,
+	TokenType,
 } from "./types";
 
 /**
  * Checks if a given token is a command if that command is a simple macro.
  */
-export function isSimpleMacro(token: LatexToken): token is SimpleMacro {
-	return token.type === LatexTokenType.Command && token.arguments.length === 0;
+export function isSimpleMacro(token: Token): token is SimpleMacro {
+	return token.type === TokenType.Command && token.arguments.length === 0;
 }
 
 /**
  * Verifies that an argument is required, has one content item and then returns the content.
  */
-export function getRequiredContentItem(arg?: LatexArgument): LatexToken | null {
+export function getRequiredContentItem(arg?: Argument): Token | null {
 	if (
 		!arg ||
-		arg.type !== LatexCommandArgumentType.Required ||
+		arg.type !== CommandArgumentType.Required ||
 		arg.content.length !== 1
 	) {
 		return null;
@@ -32,9 +32,7 @@ export function getRequiredContentItem(arg?: LatexArgument): LatexToken | null {
 /**
  * Verifies that an argument is required and contains a simple macro and returns the macro.
  */
-export function getRequiredSimpleMacro(
-	arg?: LatexArgument,
-): CommandToken | null {
+export function getRequiredSimpleMacro(arg?: Argument): CommandToken | null {
 	const token = getRequiredContentItem(arg);
 	if (!token || !isSimpleMacro(token)) {
 		return null;
@@ -46,9 +44,9 @@ export function getRequiredSimpleMacro(
 /**
  * Verifies that an argument is required and contains content and returns the content's literal.
  */
-export function getRequiredContent(arg?: LatexArgument): string | null {
+export function getRequiredContent(arg?: Argument): string | null {
 	const token = getRequiredContentItem(arg);
-	if (!token || token.type !== LatexTokenType.Content) {
+	if (!token || token.type !== TokenType.Content) {
 		return null;
 	}
 


### PR DESCRIPTION
Closes #14

## Changes
* Expand lexer accent types to allow more than just tilde and circumflex
* Change how accents are detected in the lexer to allow for accents that allow a single character or a following block and those that only allow blocks
* Remove leading "Latex_" from all types